### PR TITLE
Add Google Cloud Platform Labels Support

### DIFF
--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -37,6 +37,10 @@ module.exports = {
       funcTemplate.properties.timeout = _.get(funcObject, 'timeout')
         || _.get(this, 'serverless.service.provider.timeout')
         || '60s';
+      funcTemplate.properties.labels = _.assign({},
+        _.get(this, 'serverless.service.provider.labels') || {},
+        _.get(funcObject, 'labels') || {},
+      );
 
       const eventType = Object.keys(funcObject.events[0])[0];
 

--- a/package/lib/compileFunctions.test.js
+++ b/package/lib/compileFunctions.test.js
@@ -238,7 +238,7 @@ describe('CompileFunctions', () => {
         func1: {
           handler: 'func1',
           labels: {
-            test: 'label'
+            test: 'label',
           },
           events: [
             { http: 'foo' },
@@ -259,7 +259,7 @@ describe('CompileFunctions', () => {
             url: 'foo',
           },
           labels: {
-            test: 'label'
+            test: 'label',
           },
         },
       }];
@@ -281,7 +281,7 @@ describe('CompileFunctions', () => {
         },
       };
       googlePackage.serverless.service.provider.labels = {
-        test: 'label'
+        test: 'label',
       };
 
       const compiledResources = [{
@@ -297,7 +297,7 @@ describe('CompileFunctions', () => {
             url: 'foo',
           },
           labels: {
-            test: 'label'
+            test: 'label',
           },
         },
       }];
@@ -317,8 +317,8 @@ describe('CompileFunctions', () => {
             { http: 'foo' },
           ],
           labels: {
-            test: 'functionLabel'
-          }
+            test: 'functionLabel',
+          },
         },
       };
       googlePackage.serverless.service.provider.labels = {

--- a/package/lib/compileFunctions.test.js
+++ b/package/lib/compileFunctions.test.js
@@ -120,6 +120,7 @@ describe('CompileFunctions', () => {
           httpsTrigger: {
             url: 'foo',
           },
+          labels: {},
         },
       }];
 
@@ -153,6 +154,7 @@ describe('CompileFunctions', () => {
           httpsTrigger: {
             url: 'foo',
           },
+          labels: {},
         },
       }];
 
@@ -186,6 +188,7 @@ describe('CompileFunctions', () => {
           httpsTrigger: {
             url: 'foo',
           },
+          labels: {},
         },
       }];
 
@@ -219,6 +222,126 @@ describe('CompileFunctions', () => {
           httpsTrigger: {
             url: 'foo',
           },
+          labels: {},
+        },
+      }];
+
+      return googlePackage.compileFunctions().then(() => {
+        expect(consoleLogStub.calledOnce).toEqual(true);
+        expect(googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources)
+          .toEqual(compiledResources);
+      });
+    });
+
+    it('should set the labels based on the functions configuration', () => {
+      googlePackage.serverless.service.functions = {
+        func1: {
+          handler: 'func1',
+          labels: {
+            test: 'label'
+          },
+          events: [
+            { http: 'foo' },
+          ],
+        },
+      };
+
+      const compiledResources = [{
+        type: 'cloudfunctions.v1beta2.function',
+        name: 'my-service-dev-func1',
+        properties: {
+          location: 'us-central1',
+          function: 'func1',
+          availableMemoryMb: 256,
+          timeout: '60s',
+          sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
+          httpsTrigger: {
+            url: 'foo',
+          },
+          labels: {
+            test: 'label'
+          },
+        },
+      }];
+
+      return googlePackage.compileFunctions().then(() => {
+        expect(consoleLogStub.calledOnce).toEqual(true);
+        expect(googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources)
+          .toEqual(compiledResources);
+      });
+    });
+
+    it('should set the labels based on the provider configuration', () => {
+      googlePackage.serverless.service.functions = {
+        func1: {
+          handler: 'func1',
+          events: [
+            { http: 'foo' },
+          ],
+        },
+      };
+      googlePackage.serverless.service.provider.labels = {
+        test: 'label'
+      };
+
+      const compiledResources = [{
+        type: 'cloudfunctions.v1beta2.function',
+        name: 'my-service-dev-func1',
+        properties: {
+          location: 'us-central1',
+          function: 'func1',
+          availableMemoryMb: 256,
+          timeout: '60s',
+          sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
+          httpsTrigger: {
+            url: 'foo',
+          },
+          labels: {
+            test: 'label'
+          },
+        },
+      }];
+
+      return googlePackage.compileFunctions().then(() => {
+        expect(consoleLogStub.calledOnce).toEqual(true);
+        expect(googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources)
+          .toEqual(compiledResources);
+      });
+    });
+
+    it('should set the labels based on the merged provider and function configuration', () => {
+      googlePackage.serverless.service.functions = {
+        func1: {
+          handler: 'func1',
+          events: [
+            { http: 'foo' },
+          ],
+          labels: {
+            test: 'functionLabel'
+          }
+        },
+      };
+      googlePackage.serverless.service.provider.labels = {
+        test: 'providerLabel',
+        secondTest: 'tested',
+      };
+
+      const compiledResources = [{
+        type: 'cloudfunctions.v1beta2.function',
+        name: 'my-service-dev-func1',
+        properties: {
+          location: 'us-central1',
+          function: 'func1',
+          availableMemoryMb: 256,
+          timeout: '60s',
+          sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
+          httpsTrigger: {
+            url: 'foo',
+          },
+          labels: {
+            test: 'functionLabel',
+            secondTest: 'tested',
+          },
         },
       }];
 
@@ -251,6 +374,7 @@ describe('CompileFunctions', () => {
           httpsTrigger: {
             url: 'foo',
           },
+          labels: {},
         },
       }];
 
@@ -303,6 +427,7 @@ describe('CompileFunctions', () => {
               path: 'some-path',
               resource: 'some-resource',
             },
+            labels: {},
           },
         },
         {
@@ -318,6 +443,7 @@ describe('CompileFunctions', () => {
               eventType: 'foo',
               resource: 'some-resource',
             },
+            labels: {},
           },
         },
       ];


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #94 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

I added a new property to the `properties` object on the function template, when compiling the functions. The resulting value, an object, is the result of merging a `labels` property on the `provider` object and a `labels` property on the function object. The function object's `labels` object takes priority, overriding properties on the provider objects's `labels`.

If no `labels` properties are defined the result is an empty object.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->
Use the following `serverless.yml` file in association with the `google-nodejs` template, changing the credentials and project values as necessary.

```yaml
service: gcf-nodejs

provider:
  name: google
  runtime: nodejs
  project: my-project
  credentials: ~/.gcloud/keyfile.json
  labels:
    app: google-nodejs-example
    test: provider-label
    

plugins:
  - serverless-google-cloudfunctions

package:
  exclude:
    - node_modules/**
    - .gitignore
    - .git/**

functions:
  first:
    handler: http
    events:
      - http: path
    labels:
      test: function-label
```

Deploy the function then login the Google Cloud Platform console and go to the Functions section. Select the function you just deployed. On the right the pane should show an `app` label with the value `google-nodejs-example` and a `test` label with the value `function-label`

## Todos:

- [X] Write tests
- [x] Write documentation
- [X] Fix linting errors
- [X] Make sure code coverage hasn't dropped
- [X] Provide verification config / commands / resources
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
