### PR TITLE
feat: distinct entryPoint and function name

### DIFF
--- a/info/lib/displayServiceInfo.js
+++ b/info/lib/displayServiceInfo.js
@@ -50,7 +50,7 @@ module.exports = {
           const region = this.options.region;
           const project = this.serverless.service.provider.project;
           const baseUrl = `https://${region}-${project}.cloudfunctions.net`;
-          const path = serviceFunc.handler; // NOTE this might change
+          const path = serviceFunc.name; // NOTE this might change
           funcResource = `${baseUrl}/${path}`;
         }
 

--- a/info/lib/displayServiceInfo.test.js
+++ b/info/lib/displayServiceInfo.test.js
@@ -117,7 +117,7 @@ describe('DisplayServiceInfo', () => {
           functions: [
             {
               name: 'func1',
-              resource: 'https://us-central1-my-project.cloudfunctions.net/handler',
+              resource: 'https://us-central1-my-project.cloudfunctions.net/my-service-dev-func1',
             },
             {
               name: 'func2',

--- a/invoke/lib/invokeFunction.js
+++ b/invoke/lib/invokeFunction.js
@@ -14,14 +14,16 @@ module.exports = {
 
   invoke() {
     const project = this.serverless.service.provider.project;
+    const service = this.serverless.service.service;
     const region = this.options.region;
+    const stage = this.options.stage || 'dev';
     let func = this.options.function;
     const data = this.options.data || '';
 
     func = getGoogleCloudFunctionName(this.serverless.service.functions, func);
 
     const params = {
-      name: `projects/${project}/locations/${region}/functions/${func}`,
+      name: `projects/${project}/locations/${region}/functions/${service}-${stage}-${func}`,
       resource: {
         data,
       },

--- a/invoke/lib/invokeFunction.test.js
+++ b/invoke/lib/invokeFunction.test.js
@@ -78,7 +78,7 @@ describe('InvokeFunction', () => {
           'functions',
           'call',
           {
-            name: 'projects/my-project/locations/us-central1/functions/foo',
+            name: 'projects/my-project/locations/us-central1/functions/my-service-dev-foo',
             resource: {
               data: '',
             },
@@ -98,7 +98,7 @@ describe('InvokeFunction', () => {
           'functions',
           'call',
           {
-            name: 'projects/my-project/locations/us-central1/functions/foo',
+            name: 'projects/my-project/locations/us-central1/functions/my-service-dev-foo',
             resource: {
               data: googleInvoke.options.data,
             },

--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -117,7 +117,8 @@ const getFunctionTemplate = (funcObject, region, sourceArchiveUrl) => { //eslint
       location: region,
       availableMemoryMb: 256,
       timeout: '60s',
-      function: funcObject.handler,
+      entryPoint: funcObject.handler,
+      function: funcObject.name,
       sourceArchiveUrl,
     },
   };

--- a/package/lib/compileFunctions.test.js
+++ b/package/lib/compileFunctions.test.js
@@ -113,7 +113,8 @@ describe('CompileFunctions', () => {
         name: 'my-service-dev-func1',
         properties: {
           location: 'us-central1',
-          function: 'func1',
+          entryPoint: 'func1',
+          function: 'my-service-dev-func1',
           availableMemoryMb: 1024,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -147,7 +148,8 @@ describe('CompileFunctions', () => {
         name: 'my-service-dev-func1',
         properties: {
           location: 'us-central1',
-          function: 'func1',
+          entryPoint: 'func1',
+          function: 'my-service-dev-func1',
           availableMemoryMb: 1024,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -181,7 +183,8 @@ describe('CompileFunctions', () => {
         name: 'my-service-dev-func1',
         properties: {
           location: 'us-central1',
-          function: 'func1',
+          entryPoint: 'func1',
+          function: 'my-service-dev-func1',
           availableMemoryMb: 256,
           timeout: '120s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -215,7 +218,8 @@ describe('CompileFunctions', () => {
         name: 'my-service-dev-func1',
         properties: {
           location: 'us-central1',
-          function: 'func1',
+          entryPoint: 'func1',
+          function: 'my-service-dev-func1',
           availableMemoryMb: 256,
           timeout: '120s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -251,7 +255,8 @@ describe('CompileFunctions', () => {
         name: 'my-service-dev-func1',
         properties: {
           location: 'us-central1',
-          function: 'func1',
+          entryPoint: 'func1',
+          function: 'my-service-dev-func1',
           availableMemoryMb: 256,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -289,7 +294,8 @@ describe('CompileFunctions', () => {
         name: 'my-service-dev-func1',
         properties: {
           location: 'us-central1',
-          function: 'func1',
+          entryPoint: 'func1',
+          function: 'my-service-dev-func1',
           availableMemoryMb: 256,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -331,7 +337,8 @@ describe('CompileFunctions', () => {
         name: 'my-service-dev-func1',
         properties: {
           location: 'us-central1',
-          function: 'func1',
+          entryPoint: 'func1',
+          function: 'my-service-dev-func1',
           availableMemoryMb: 256,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -367,7 +374,8 @@ describe('CompileFunctions', () => {
         name: 'my-service-dev-func1',
         properties: {
           location: 'us-central1',
-          function: 'func1',
+          entryPoint: 'func1',
+          function: 'my-service-dev-func1',
           availableMemoryMb: 256,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -418,7 +426,8 @@ describe('CompileFunctions', () => {
           name: 'my-service-dev-func1',
           properties: {
             location: 'us-central1',
-            function: 'func1',
+            entryPoint: 'func1',
+            function: 'my-service-dev-func1',
             availableMemoryMb: 256,
             timeout: '60s',
             sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -435,7 +444,8 @@ describe('CompileFunctions', () => {
           name: 'my-service-dev-func2',
           properties: {
             location: 'us-central1',
-            function: 'func2',
+            entryPoint: 'func2',
+            function: 'my-service-dev-func2',
             availableMemoryMb: 256,
             timeout: '60s',
             sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',


### PR DESCRIPTION
This PR differentiates the name of the function with the name of the entry point.

This allows the stage to be used correctly. This will create for the same code, a function per stage.

I change in:
- Deploy, the template use `entryPoint` and name
- Invoke, the name of function change and use stage
- Info, display the good name 

## Test

With this config

```yaml
service: images

provider:
  name: google
  runtime: nodejs
  # the path to the credentials file needs to be absolute

plugins:
  - serverless-google-cloudfunctions

# needs more granular excluding in production as only the serverless provider npm
# package should be excluded (and not the whole node_modules directory)
package:
  exclude:
    - node_modules/**
    - .gitignore
    - .git/**

functions:
  images:
    handler: images
    events:
      - http: path
```

I can deploy on prod and dev with the same handler.

<img width="837" alt="capture d ecran 2018-03-20 a 16 01 31" src="https://user-images.githubusercontent.com/1083083/37662732-fad05e2c-2c57-11e8-86fc-a7a6a60ce0aa.png">

I use command

```sh
serverless deploy --stage prod
```
and 

```sh
serverless deploy 
```

## Warning

By default in serverless framework https://github.com/serverless/serverless/blob/master/lib/classes/Service.js#L20 the stage is dev. So when I deploy without stage option my function name is `service`-dev-`functionName`.