### PR TITLE
Added support for entryPoint option, to explicitly define the exporte…

### DIFF
--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -37,6 +37,8 @@ module.exports = {
       funcTemplate.properties.timeout = _.get(funcObject, 'timeout')
         || _.get(this, 'serverless.service.provider.timeout')
         || '60s';
+      funcTemplate.properties.entryPoint = _.get(funcObject, 'entryPoint')
+        || _.get(funcTemplate, 'properties.function');
       funcTemplate.properties.labels = _.assign({},
         _.get(this, 'serverless.service.provider.labels') || {},
         _.get(funcObject, 'labels') || {},

--- a/package/lib/compileFunctions.test.js
+++ b/package/lib/compileFunctions.test.js
@@ -114,6 +114,7 @@ describe('CompileFunctions', () => {
         properties: {
           location: 'us-central1',
           function: 'func1',
+          entryPoint: 'func1',
           availableMemoryMb: 1024,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -148,6 +149,7 @@ describe('CompileFunctions', () => {
         properties: {
           location: 'us-central1',
           function: 'func1',
+          entryPoint: 'func1',
           availableMemoryMb: 1024,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -165,7 +167,43 @@ describe('CompileFunctions', () => {
       });
     });
 
-    it('should set the timout based on the functions configuration', () => {
+    it('should set entryPoint based on the functions configuration', () => {
+      googlePackage.serverless.service.functions = {
+        func1: {
+          handler: 'func1',
+          entryPoint: 'entry1',
+          events: [
+            { http: 'foo' },
+          ],
+        },
+      };
+      googlePackage.serverless.service.provider.memorySize = 1024;
+
+      const compiledResources = [{
+        type: 'cloudfunctions.v1beta2.function',
+        name: 'my-service-dev-func1',
+        properties: {
+          location: 'us-central1',
+          function: 'func1',
+          entryPoint: 'entry1',
+          availableMemoryMb: 1024,
+          timeout: '60s',
+          sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
+          httpsTrigger: {
+            url: 'foo',
+          },
+          labels: {},
+        },
+      }];
+
+      return googlePackage.compileFunctions().then(() => {
+        expect(consoleLogStub.calledOnce).toEqual(true);
+        expect(googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources)
+          .toEqual(compiledResources);
+      });
+    });
+
+    it('should set the timeout based on the functions configuration', () => {
       googlePackage.serverless.service.functions = {
         func1: {
           handler: 'func1',
@@ -182,6 +220,7 @@ describe('CompileFunctions', () => {
         properties: {
           location: 'us-central1',
           function: 'func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           timeout: '120s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -216,6 +255,7 @@ describe('CompileFunctions', () => {
         properties: {
           location: 'us-central1',
           function: 'func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           timeout: '120s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -252,6 +292,7 @@ describe('CompileFunctions', () => {
         properties: {
           location: 'us-central1',
           function: 'func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -290,6 +331,7 @@ describe('CompileFunctions', () => {
         properties: {
           location: 'us-central1',
           function: 'func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -332,6 +374,7 @@ describe('CompileFunctions', () => {
         properties: {
           location: 'us-central1',
           function: 'func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -368,6 +411,7 @@ describe('CompileFunctions', () => {
         properties: {
           location: 'us-central1',
           function: 'func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -419,6 +463,7 @@ describe('CompileFunctions', () => {
           properties: {
             location: 'us-central1',
             function: 'func1',
+            entryPoint: 'func1',
             availableMemoryMb: 256,
             timeout: '60s',
             sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -436,6 +481,7 @@ describe('CompileFunctions', () => {
           properties: {
             location: 'us-central1',
             function: 'func2',
+            entryPoint: 'func2',
             availableMemoryMb: 256,
             timeout: '60s',
             sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',


### PR DESCRIPTION
…d function to use - defaults to handler's name.

Use case: I was trying to write another plugin that would dynamically change the gcloud function's name based on the CI branch. For example my `serverless.yml`:
```
functions:
  login:
    handler: login
    events:
      - http: path
```

would be dynamically changed by my plugin to:
```
functions:
  develop-login:
    handler: develop-login
    entryPoint: login
    events:
      - http: path
```

Since Google defaults the `entryPoint` to be the same as our `handler`, the deployment was always ending with an error saying that my exported function `develop-login` does not exist...

This PR allows us to explicitly set the entryPoint to each function (if not, it'll still default to the `handler`)