### PR TITLE
Add provider based region support

### DIFF
--- a/shared/utils.js
+++ b/shared/utils.js
@@ -7,13 +7,13 @@ module.exports = {
   setDefaults() {
     this.options.stage = _.get(this, 'options.stage')
       || 'dev';
-    
-    // serverless framework is hard-coding us-east-1 region from aws 
+
+    // serverless framework is hard-coding us-east-1 region from aws
     // this is temporary fix for multiple regions
     const region = _.get(this, 'options.region')
       || _.get(this, 'serverless.service.provider.region');
 
-    this.options.region = (!region || region === 'us-east-1') 
+    this.options.region = (!region || region === 'us-east-1')
       ? 'us-central1' : region;
 
     return BbPromise.resolve();

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -8,6 +8,7 @@ module.exports = {
     this.options.stage = _.get(this, 'options.stage')
       || 'dev';
     this.options.region = _.get(this, 'options.region')
+      || _.get(this, 'serverless.service.provider.region')
       || 'us-central1';
 
     return BbPromise.resolve();

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -7,9 +7,14 @@ module.exports = {
   setDefaults() {
     this.options.stage = _.get(this, 'options.stage')
       || 'dev';
-    this.options.region = _.get(this, 'options.region')
-      || _.get(this, 'serverless.service.provider.region')
-      || 'us-central1';
+    
+    // serverless framework is hard-coding us-east-1 region from aws 
+    // this is temporary fix for multiple regions
+    const region = _.get(this, 'options.region')
+      || _.get(this, 'serverless.service.provider.region');
+
+    this.options.region = (!region || region === 'us-east-1') 
+      ? 'us-central1' : region;
 
     return BbPromise.resolve();
   },

--- a/shared/utils.test.js
+++ b/shared/utils.test.js
@@ -31,5 +31,17 @@ describe('Utils', () => {
         expect(googleCommand.options.region).toEqual('my-region');
       });
     });
+
+
+    it('should set the provider values for stage and region if provided', () => {
+      googleCommand.serverless.service.provider = {
+        region: 'my-region',
+      };
+
+      return googleCommand.setDefaults().then(() => {
+        expect(googleCommand.options.region).toEqual('my-region');
+      });
+    });
+
   });
 });

--- a/shared/utils.test.js
+++ b/shared/utils.test.js
@@ -42,6 +42,5 @@ describe('Utils', () => {
         expect(googleCommand.options.region).toEqual('my-region');
       });
     });
-
   });
 });


### PR DESCRIPTION
New regions are officially available outside US. 
https://cloud.google.com/functions/docs/locations

PR #43 was removed before because of issue https://github.com/serverless/serverless/issues/3332. Serverless framework hard-coding us-east-1 region which does not exist in GCF. 
This PR ignores this region, replacing to default region `us-central1`


