### PR TITLE
Allow setting provider.region and provider.stage in serverless.yml

### DIFF
--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -34,6 +34,9 @@ module.exports = {
       funcTemplate.properties.availableMemoryMb = _.get(funcObject, 'memorySize')
         || _.get(this, 'serverless.service.provider.memorySize')
         || 256;
+      funcTemplate.properties.runtime = _.get(funcObject, 'runtime')
+        || _.get(this, 'serverless.service.provider.runtime')
+        || 'nodejs';
       funcTemplate.properties.timeout = _.get(funcObject, 'timeout')
         || _.get(this, 'serverless.service.provider.timeout')
         || '60s';

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -6,8 +6,10 @@ const BbPromise = require('bluebird');
 module.exports = {
   setDefaults() {
     this.options.stage = _.get(this, 'options.stage')
+      || _.get(this, 'serverless.service.provider.stage')
       || 'dev';
     this.options.region = _.get(this, 'options.region')
+      || _.get(this, 'serverless.service.provider.region')
       || 'us-central1';
 
     return BbPromise.resolve();


### PR DESCRIPTION
This allows you to specify defaults for `sls deploy` and other commands, like in the AWS provider. Also allows setting function runtimes in either provider or function definitions. They will work as follows in serverless.yml:

    provider:
      stage: prod
      region: europe-west1
      runtime: nodejs8