### PR TITLE
Fix Unexpected token : in JSON

### DIFF
--- a/shared/monitorDeployment.js
+++ b/shared/monitorDeployment.js
@@ -48,7 +48,7 @@ module.exports = {
                 return callback();
               })
               .catch((error) => {
-                reject(new Error(error.message));
+                reject(error);
               });
           }, frequency);
         },
@@ -66,8 +66,7 @@ module.exports = {
 const throwErrorIfDeploymentFails = (deployment) => {
   if (deployment.operation.error && deployment.operation.error.errors.length) {
     const errorCode = deployment.operation.error.errors[0].code;
-    const parsedMessage = JSON.parse(deployment.operation.error.errors[0].message);
-    const parsedDetails = JSON.stringify(parsedMessage);
+    const parsedDetails = deployment.operation.error.errors[0].message;
     const errorMessage = [
       `Deployment failed: ${errorCode}\n\n`,
       `     ${parsedDetails}`,


### PR DESCRIPTION
This fixes a bug where the deployment itself was legitimately failing, but the error handling itself failed.

Specifically, I noticed that the error being thrown was unnecessarily hiding the actual error, which obfuscated the real issue. The real issue was that the error message was expected to return valid JSON, but it was pseudo-JSON instead (no surrounding `{}`). By removing the redundant JSON.stringify(JSON.parse(...)) wrapping of the message I was able to see the actual issue in my case:

> "/httpsTrigger/url": domain: validation; keyword: type; message: instance does not match any allowed primitive type; allowed: ["string"]; found: "object"

which allowed me to realize that what I had done in the past with AWS Lambda was not valid for GCP Cloud Functions (specifically specifying the HTTP event with a method and cors support).

Closes #78 