### PR TITLE
support GOOGLE_APPLICATION_CREDENTIALS env variable

### DIFF
--- a/provider/googleProvider.js
+++ b/provider/googleProvider.js
@@ -61,7 +61,7 @@ class GoogleProvider {
   }
 
   getAuthClient() {
-    let credentials = this.serverless.service.provider.credentials;
+    let credentials = this.serverless.service.provider.credentials || process.env.GOOGLE_APPLICATION_CREDENTIALS;
     const credParts = credentials.split(path.sep);
 
     if (credParts[0] === '~') {

--- a/provider/googleProvider.js
+++ b/provider/googleProvider.js
@@ -61,7 +61,8 @@ class GoogleProvider {
   }
 
   getAuthClient() {
-    let credentials = this.serverless.service.provider.credentials || process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    let credentials = this.serverless.service.provider.credentials
+      || process.env.GOOGLE_APPLICATION_CREDENTIALS;
     const credParts = credentials.split(path.sep);
 
     if (credParts[0] === '~') {


### PR DESCRIPTION
Support to use the GOOGLE_APPLICATION_CREDENTIALS environment variable instead of the provider credentials parameters as described in #122.