### PR TITLE
Set google options config

### DIFF
--- a/provider/googleProvider.js
+++ b/provider/googleProvider.js
@@ -7,6 +7,8 @@ const os = require('os');
 const _ = require('lodash');
 const google = require('googleapis').google;
 
+const packageJson = require('../package.json');
+
 const constants = {
   providerName: 'google',
 };
@@ -21,7 +23,18 @@ class GoogleProvider {
     this.provider = this; // only load plugin in a Google service context
     this.serverless.setProvider(constants.providerName, this);
 
+    const serverlessVersion = this.serverless.version;
+    const pluginVersion = packageJson.version;
+    const googleApisVersion = packageJson.dependencies.googleapis;
+
+    google.options({
+      headers: {
+        'User-Agent': `Serverless/${serverlessVersion} Serverless-Google-Provider/${pluginVersion} Googleapis/${googleApisVersion}`,
+      },
+    });
+
     this.sdk = {
+      google,
       deploymentmanager: google.deploymentmanager('v2'),
       storage: google.storage('v1'),
       logging: google.logging('v2'),

--- a/provider/googleProvider.test.js
+++ b/provider/googleProvider.test.js
@@ -18,6 +18,7 @@ describe('GoogleProvider', () => {
 
   beforeEach(() => {
     serverless = new Serverless();
+    serverless.version = '1.0.0';
     serverless.service = {
       provider: {
         project: 'example-project',
@@ -58,6 +59,8 @@ describe('GoogleProvider', () => {
     });
 
     it('should set the used SDKs', () => {
+      expect(googleProvider.sdk.google).toBeDefined();
+
       expect(googleProvider.sdk.deploymentmanager)
         .toBeDefined();
 
@@ -69,6 +72,11 @@ describe('GoogleProvider', () => {
 
       expect(googleProvider.sdk.cloudfunctions)
         .toBeDefined();
+    });
+
+    it('should set the google options', () => {
+      expect(google._options.headers['User-Agent']) // eslint-disable-line no-underscore-dangle
+        .toMatch(/Serverless\/.+ Serverless-Google-Provider\/.+ Googleapis\/.+/);
     });
   });
 


### PR DESCRIPTION
Sets the options config before storing the used service instances in the `this.sdk` object.

/cc @brianneisler 