### PR TITLE
Add mappers from the aws runtime names to the gcp equivalents

### DIFF
--- a/shared/utils.js
+++ b/shared/utils.js
@@ -6,7 +6,16 @@ const BbPromise = require('bluebird');
 module.exports = {
   setDefaults() {
     this.options.stage = _.get(this, 'options.stage') || _.get(this, 'serverless.service.provider.stage') || 'dev';
-    this.options.runtime = _.get(this, 'options.runtime') || 'nodejs8';
+    // Support aws defined runtimes and map to gcp definitions
+    const AWSRuntimes = {
+      "nodejs8.10": "nodejs8",
+      // Can't tell if this is right, it's just documented as the "default"
+      //"nodejs6.10": "nodejs6",
+      "python3.7":  "python37",
+      "go1.x":      "go111",
+    }
+    const userDefinedRuntime = _.get(this, 'options.runtime');
+    this.options.runtime = AWSRuntimes[userDefinedRuntime] || userDefinedRuntime || 'nodejs8';
 
     // serverless framework is hard-coding us-east-1 region from aws
     // this is temporary fix for multiple regions

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -8,12 +8,12 @@ module.exports = {
     this.options.stage = _.get(this, 'options.stage') || _.get(this, 'serverless.service.provider.stage') || 'dev';
     // Support aws defined runtimes and map to gcp definitions
     const AWSRuntimes = {
-      "nodejs8.10": "nodejs8",
-      // Can't tell if this is right, it's just documented as the "default"
-      //"nodejs6.10": "nodejs6",
-      "python3.7":  "python37",
-      "go1.x":      "go111",
-    }
+      'nodejs8.10': 'nodejs8',
+      // Can't tell if this is right, it's just documented as the 'default'
+      // 'nodejs6.10': 'nodejs6',
+      'python3.7': 'python37',
+      'go1.x': 'go111',
+    };
     const userDefinedRuntime = _.get(this, 'options.runtime');
     this.options.runtime = AWSRuntimes[userDefinedRuntime] || userDefinedRuntime || 'nodejs8';
 

--- a/shared/utils.test.js
+++ b/shared/utils.test.js
@@ -37,6 +37,20 @@ describe('Utils', () => {
         expect(googleCommand.options.region).toEqual('my-region');
         expect(googleCommand.options.runtime).toEqual('nodejs6');
       });
+
+    });
+
+    it('should handle AWS runtime values where applicable', () => {
+      var runtimes = [['nodejs8.10', 'nodejs8'],
+                      ['python3.7', 'python37'],
+                      ['go1.x', 'go111']];
+      for(var r = 0; r < runtimes.length; r++) {
+        var runtime = runtimes[r];
+        googleCommand.options.runtime = runtime[0];
+        return googleCommand.setDefaults().then(() => {
+          expect(googleCommand.options.runtime).toEqual(runtime[1]);
+        });
+      }
     });
 
 

--- a/shared/utils.test.js
+++ b/shared/utils.test.js
@@ -37,18 +37,19 @@ describe('Utils', () => {
         expect(googleCommand.options.region).toEqual('my-region');
         expect(googleCommand.options.runtime).toEqual('nodejs6');
       });
-
     });
 
-    it('should handle AWS runtime values where applicable', () => {
-      var runtimes = [['nodejs8.10', 'nodejs8'],
-                      ['python3.7', 'python37'],
-                      ['go1.x', 'go111']];
-      for(var r = 0; r < runtimes.length; r++) {
-        var runtime = runtimes[r];
-        googleCommand.options.runtime = runtime[0];
-        return googleCommand.setDefaults().then(() => {
-          expect(googleCommand.options.runtime).toEqual(runtime[1]);
+    describe('Iterating through AWS runtime values', () => {
+      const runtimes = [['nodejs8.10', 'nodejs8'],
+                        ['python3.7', 'python37'],
+                        ['go1.x', 'go111']];
+      for (let r = 0; r < runtimes.length; r += 1) {
+        const runtime = runtimes[r];
+        it(`should return the appropriate GCP value for ${runtime[0]}`, () => {
+          googleCommand.options.runtime = runtime[0];
+          return googleCommand.setDefaults().then(() => {
+            expect(googleCommand.options.runtime).toEqual(runtime[1]);
+          });
         });
       }
     });


### PR DESCRIPTION
In moving my function from AWS to GCP one of the issues I ran into was runtime names. Since they map pretty easily between AWS->GCP it seems relevant to accept the AWS runtimes given that the most accessible documentation references AWS available runtimes.

I'm open to any thoughts or feedback though, my hope is that this can just make it easier for those that are new to any of this.