### PR TITLE
Handle integer values for timeout.

### DIFF
--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -40,7 +40,12 @@ module.exports = {
       funcTemplate.properties.runtime = _.get(funcObject, 'runtime')
         || _.get(this, 'serverless.service.provider.runtime')
         || 'nodejs8';
-      funcTemplate.properties.timeout = _.get(funcObject, 'timeout')
+      // AWS format assumes seconds, so if the timeout is specified at the function assume seconds
+      let userDefinedTimeout = _.get(funcObject, 'timeout');
+      if (userDefinedTimeout && !isNaN(parseInt(userDefinedTimeout.substr(-1), 10))) {
+        userDefinedTimeout += 's';
+      }
+      funcTemplate.properties.timeout = userDefinedTimeout
         || _.get(this, 'serverless.service.provider.timeout')
         || '60s';
       funcTemplate.properties.environmentVariables = _.merge(

--- a/package/lib/compileFunctions.test.js
+++ b/package/lib/compileFunctions.test.js
@@ -238,6 +238,23 @@ describe('CompileFunctions', () => {
       });
     });
 
+    it('should handle an integer timeout value and convert it to a gcp string ending in "s"', () => {
+      googlePackage.serverless.service.functions = {
+        func1: {
+          handler: 'func1',
+          timeout: '120',
+          events: [
+            { http: 'foo' },
+          ],
+        },
+      };
+
+      return googlePackage.compileFunctions().then(() => {
+        expect(googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources[0]
+          .properties.timeout).toEqual('120s');
+      });
+    });
+
     it('should set the labels based on the functions configuration', () => {
       googlePackage.serverless.service.functions = {
         func1: {


### PR DESCRIPTION
In moving my function from AWS to GCP one of the issues I ran into was the timeout value. Since the difference between AWS and GCP was "120" vs "120s", it seems relevant to accept the AWS seconds integer given that the most accessible documentation references AWS values.

I'm open to any thoughts or feedback though, my hope is that this can just make it easier for those that are new to any of this.