### PR TITLE
compileFunctions: merge environmentVariables to a new object

### DIFF
--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -43,7 +43,7 @@ module.exports = {
       funcTemplate.properties.timeout = _.get(funcObject, 'timeout')
         || _.get(this, 'serverless.service.provider.timeout')
         || '60s';
-      funcTemplate.properties.environmentVariables = _.merge(
+      funcTemplate.properties.environmentVariables = _.merge({},
         _.get(this, 'serverless.service.provider.environment'),
         funcObject.environment // eslint-disable-line comma-dangle
       );


### PR DESCRIPTION
Fixes overwriting of environmentVariables for multiple functions