### PR TITLE
add the ability to define vpcConnector

### DIFF
--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -48,6 +48,11 @@ module.exports = {
         funcObject.environment // eslint-disable-line comma-dangle
       );
 
+      if (_.get(funcObject, 'vpcConnector') || _.get(this, 'serverless.service.provider.vpcConnector')) {
+        funcTemplate.properties.vpcConnector = _.get(funcObject, 'vpcConnector')
+          || _.get(this, 'serverless.service.provider.vpcConnector');
+      }
+
       if (!_.size(funcTemplate.properties.environmentVariables)) {
         delete funcTemplate.properties.environmentVariables;
       }

--- a/package/lib/compileFunctions.test.js
+++ b/package/lib/compileFunctions.test.js
@@ -440,6 +440,78 @@ describe('CompileFunctions', () => {
       });
     });
 
+    it('should set the vpcConnector based on the function configuration', () => {
+      googlePackage.serverless.service.functions = {
+        func1: {
+          handler: 'func1',
+          vpcConnector: 'projects/PROJECT_ID/locations/us-central1/connectors/my-connector',
+          events: [
+            { http: 'foo' },
+          ],
+        },
+      };
+
+      const compiledResources = [{
+        type: 'cloudfunctions.v1beta2.function',
+        name: 'my-service-dev-func1',
+        properties: {
+          location: 'us-central1',
+          runtime: 'nodejs8',
+          function: 'func1',
+          availableMemoryMb: 256,
+          vpcConnector: 'projects/PROJECT_ID/locations/us-central1/connectors/my-connector',
+          timeout: '60s',
+          sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
+          httpsTrigger: {
+            url: 'foo',
+          },
+          labels: {},
+        },
+      }];
+
+      return googlePackage.compileFunctions().then(() => {
+        expect(consoleLogStub.calledOnce).toEqual(true);
+        expect(googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources)
+          .toEqual(compiledResources);
+      });
+    });
+
+    it('should set the vpcConnector based on the provider configuration', () => {
+      googlePackage.serverless.service.functions = {
+        func1: {
+          handler: 'func1',
+          events: [
+            { http: 'foo' },
+          ],
+        },
+      };
+      googlePackage.serverless.service.provider.vpcConnector = 'projects/PROJECT_ID/locations/us-central1/connectors/my-connector';
+
+      const compiledResources = [{
+        type: 'cloudfunctions.v1beta2.function',
+        name: 'my-service-dev-func1',
+        properties: {
+          location: 'us-central1',
+          runtime: 'nodejs8',
+          function: 'func1',
+          availableMemoryMb: 256,
+          vpcConnector: 'projects/PROJECT_ID/locations/us-central1/connectors/my-connector',
+          timeout: '60s',
+          sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
+          httpsTrigger: {
+            url: 'foo',
+          },
+          labels: {},
+        },
+      }];
+
+      return googlePackage.compileFunctions().then(() => {
+        expect(consoleLogStub.calledOnce).toEqual(true);
+        expect(googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources)
+          .toEqual(compiledResources);
+      });
+    });
+
     it('should compile "http" events properly', () => {
       googlePackage.serverless.service.functions = {
         func1: {


### PR DESCRIPTION
This simple PR exposes the ability to define vpcConnector for a google cloud function. You can read more documentation about vpcConnectors in the official documentation: https://cloud.google.com/functions/docs/connecting-vpc

Please let me know what needs to be added/changed to get this PR landed 👍 I have tested this locally and it works perfectly!