### PR TITLE
Fix lodash merge function not to update original object.

### DIFF
--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -44,6 +44,7 @@ module.exports = {
         || _.get(this, 'serverless.service.provider.timeout')
         || '60s';
       funcTemplate.properties.environmentVariables = _.merge(
+        {},
         _.get(this, 'serverless.service.provider.environment'),
         funcObject.environment // eslint-disable-line comma-dangle
       );


### PR DESCRIPTION
## Fixed
Do not overwrite `serverless.service.provider.environment` property on `compileFunctions()`.

See https://lodash.com/docs/4.17.11#merge
> Note: This method mutates object.

## Test added

- Check merge priority, variable is updated by function's `environment` property.
- `serverless.service.provider.environment` isn't overwritten after `compileFunctions()` .

## Related Issue

- #167 
- #162 : This fixes same issue. I also made tests to check specification.