### PR TITLE
GCP VPC Support and Unit Test fix

### DIFF
--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -23,7 +23,7 @@ module.exports = {
 
       validateHandlerProperty(funcObject, functionName);
       validateEventsProperty(funcObject, functionName);
-      validateVpcConnectorProprety(funcObject, functionName);
+      validateVpcConnectorProperty(funcObject, functionName);
 
       const funcTemplate = getFunctionTemplate(
         funcObject,
@@ -131,13 +131,13 @@ const validateEventsProperty = (funcObject, functionName) => {
   }
 };
 
-const validateVpcConnectorProprety = (funcObject, functionName) => {
+const validateVpcConnectorProperty = (funcObject, functionName) => {
   if (funcObject.vpc && typeof funcObject.vpc === 'string') {
     const vpcNamePattern = /projects\/[\s\S]*\/locations\/[\s\S]*\/connectors\/[\s\S]*/i;
     if (!vpcNamePattern.test(funcObject.vpc)) {
       const errorMessage = [
         `The function "${functionName}" has invalid vpc connection name`,
-        'VPC Connector name should follow projects/{project_id}/locations/{region}/connectors/{connector_name}',
+        ' VPC Connector name should follow projects/{project_id}/locations/{region}/connectors/{connector_name}',
         ' Please check the docs for more info.',
       ].join('');
       throw new Error(errorMessage);

--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -23,6 +23,7 @@ module.exports = {
 
       validateHandlerProperty(funcObject, functionName);
       validateEventsProperty(funcObject, functionName);
+      validateVpcConnectorProprety(funcObject, functionName);
 
       const funcTemplate = getFunctionTemplate(
         funcObject,
@@ -48,6 +49,11 @@ module.exports = {
         _.get(this, 'serverless.service.provider.environment'),
         funcObject.environment // eslint-disable-line comma-dangle
       );
+
+      if (funcObject.vpc) {
+        _.assign(funcTemplate.properties, { vpcConnector: _.get(funcObject, 'vpc')
+         || _.get(this, 'serverless.service.provider.vpc') });
+      }
 
       if (!_.size(funcTemplate.properties.environmentVariables)) {
         delete funcTemplate.properties.environmentVariables;
@@ -122,6 +128,20 @@ const validateEventsProperty = (funcObject, functionName) => {
       ` supported event types are: ${supportedEvents.join(', ')}`,
     ].join('');
     throw new Error(errorMessage);
+  }
+};
+
+const validateVpcConnectorProprety = (funcObject, functionName) => {
+  if (funcObject.vpc && typeof funcObject.vpc === 'string') {
+    const vpcNamePattern = /projects\/[\s\S]*\/locations\/[\s\S]*\/connectors\/[\s\S]*/i;
+    if (!vpcNamePattern.test(funcObject.vpc)) {
+      const errorMessage = [
+        `The function "${functionName}" has invalid vpc connection name`,
+        'VPC Connector name should follow projects/{project_id}/locations/{region}/connectors/{connector_name}',
+        ' Please check the docs for more info.',
+      ].join('');
+      throw new Error(errorMessage);
+    }
   }
 };
 


### PR DESCRIPTION
This PR include below changes:
1. Add GCP vpc support
2. Fix the unit test in compileFunction.test.js 

Related Issue:
https://github.com/serverless/serverless-google-cloudfunctions/issues/190

Other reference:
https://cloud.google.com/functions/docs/connecting-vpc
https://github.com/googleapis/google-api-nodejs-client/blob/master/src/apis/cloudfunctions/v1.ts#L272