### PR TITLE
Fix function name on invoke

### DIFF
--- a/invoke/lib/invokeFunction.js
+++ b/invoke/lib/invokeFunction.js
@@ -65,5 +65,5 @@ const getGoogleCloudFunctionName = (serviceFunctions, func) => {
     throw new Error(errorMessage);
   }
 
-  return serviceFunctions[func].handler;
+  return serviceFunctions[func].name;
 };

--- a/invoke/lib/invokeFunction.test.js
+++ b/invoke/lib/invokeFunction.test.js
@@ -23,6 +23,7 @@ describe('InvokeFunction', () => {
     serverless.service.functions = {
       func1: {
         handler: 'foo',
+        name: 'full-function-name',
       },
     };
     serverless.setProvider('google', new GoogleProvider(serverless));
@@ -77,7 +78,7 @@ describe('InvokeFunction', () => {
             'functions',
             'call',
             {
-              name: 'projects/my-project/locations/us-central1/functions/foo',
+              name: 'projects/my-project/locations/us-central1/functions/full-function-name',
               resource: {
                 data: '',
               },
@@ -100,7 +101,7 @@ describe('InvokeFunction', () => {
             'functions',
             'call',
             {
-              name: 'projects/my-project/locations/us-central1/functions/foo',
+              name: 'projects/my-project/locations/us-central1/functions/full-function-name',
               resource: {
                 data: googleInvoke.options.data,
               },


### PR DESCRIPTION
When calling `invoke`, the function name is not correct, giving a `Function XXX (…) does not exist` error. This is because the function _handler_ was used instead of the function _name_.

Fixes #212

Fixes #213 