### PR TITLE
feat: add support for allowUnauthenticated and custom IAM definitions

### DIFF
--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -90,7 +90,7 @@ module.exports = {
         funcTemplate.properties.httpsTrigger = {};
         funcTemplate.properties.httpsTrigger.url = url;
 
-        if (funcObject.allowUnauthenticated === true) {
+        if (funcObject.allowUnauthenticated) {
           funcTemplate.accessControl.gcpIamPolicy.bindings = _.unionBy(
             [{ role: 'roles/cloudfunctions.invoker', members: ['allUsers'] }],
             funcTemplate.accessControl.gcpIamPolicy.bindings,

--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -90,7 +90,7 @@ module.exports = {
         funcTemplate.properties.httpsTrigger = {};
         funcTemplate.properties.httpsTrigger.url = url;
 
-        if (_.get(funcObject, 'allowUnauthenticated') === true) {
+        if (funcObject.allowUnauthenticated === true) {
           funcTemplate.accessControl.gcpIamPolicy.bindings = _.unionBy(
             [{ role: 'roles/cloudfunctions.invoker', members: ['allUsers'] }],
             funcTemplate.accessControl.gcpIamPolicy.bindings,
@@ -109,7 +109,7 @@ module.exports = {
         funcTemplate.properties.eventTrigger.resource = resource;
       }
 
-      if (!_.size(funcTemplate.accessControl.gcpIamPolicy.bindings)) {
+      if (!funcTemplate.accessControl.gcpIamPolicy.bindings.length) {
         delete funcTemplate.accessControl;
       }
 
@@ -186,7 +186,7 @@ const validateIamProperty = (funcObject, functionName) => {
         ].join('');
         throw new Error(errorMessage);
       }
-      if (!binding.members || binding.members.length === 0) {
+      if (!Array.isArray(binding.members) || !binding.members.length) {
         const errorMessage = [
           `The function "${functionName}" has no members specified for an IAM binding.`,
           ' Each binding requires at least one member to be assigned. See the IAM documentation',

--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -24,6 +24,7 @@ module.exports = {
       validateHandlerProperty(funcObject, functionName);
       validateEventsProperty(funcObject, functionName);
       validateVpcConnectorProperty(funcObject, functionName);
+      validateIamProperty(funcObject, functionName);
 
       const funcTemplate = getFunctionTemplate(
         funcObject,
@@ -50,6 +51,11 @@ module.exports = {
         {},
         _.get(this, 'serverless.service.provider.environment'),
         funcObject.environment // eslint-disable-line comma-dangle
+      );
+      funcTemplate.accessControl.gcpIamPolicy.bindings = _.unionBy(
+        _.get(funcObject, 'iam.bindings'),
+        _.get(this, 'serverless.service.provider.iam.bindings'),
+        'role'
       );
 
       if (!funcTemplate.properties.serviceAccountEmail) {
@@ -83,6 +89,14 @@ module.exports = {
 
         funcTemplate.properties.httpsTrigger = {};
         funcTemplate.properties.httpsTrigger.url = url;
+
+        if (_.get(funcObject, 'allowUnauthenticated') === true) {
+          funcTemplate.accessControl.gcpIamPolicy.bindings = _.unionBy(
+            [{ role: 'roles/cloudfunctions.invoker', members: ['allUsers'] }],
+            funcTemplate.accessControl.gcpIamPolicy.bindings,
+            'role'
+          );
+        }
       }
       if (eventType === 'event') {
         const type = funcObject.events[0].event.eventType;
@@ -93,6 +107,10 @@ module.exports = {
         funcTemplate.properties.eventTrigger.eventType = type;
         if (path) funcTemplate.properties.eventTrigger.path = path;
         funcTemplate.properties.eventTrigger.resource = resource;
+      }
+
+      if (!_.size(funcTemplate.accessControl.gcpIamPolicy.bindings)) {
+        delete funcTemplate.accessControl;
       }
 
       this.serverless.service.provider.compiledConfigurationTemplate.resources.push(funcTemplate);
@@ -157,6 +175,29 @@ const validateVpcConnectorProperty = (funcObject, functionName) => {
   }
 };
 
+const validateIamProperty = (funcObject, functionName) => {
+  if (_.get(funcObject, 'iam.bindings') && funcObject.iam.bindings.length > 0) {
+    funcObject.iam.bindings.forEach((binding) => {
+      if (!binding.role) {
+        const errorMessage = [
+          `The function "${functionName}" has no role specified for an IAM binding.`,
+          ' Each binding requires a role. For details on supported roles, see the documentation',
+          ' at: https://cloud.google.com/iam/docs/understanding-roles',
+        ].join('');
+        throw new Error(errorMessage);
+      }
+      if (!binding.members || binding.members.length === 0) {
+        const errorMessage = [
+          `The function "${functionName}" has no members specified for an IAM binding.`,
+          ' Each binding requires at least one member to be assigned. See the IAM documentation',
+          ' for details on configuring members: https://cloud.google.com/iam/docs/overview',
+        ].join('');
+        throw new Error(errorMessage);
+      }
+    });
+  }
+};
+
 const getFunctionTemplate = (funcObject, projectName, region, sourceArchiveUrl) => {
   //eslint-disable-line
   return {
@@ -170,6 +211,11 @@ const getFunctionTemplate = (funcObject, projectName, region, sourceArchiveUrl) 
       entryPoint: funcObject.handler,
       function: funcObject.name,
       sourceArchiveUrl,
+    },
+    accessControl: {
+      gcpIamPolicy: {
+        bindings: [],
+      },
     },
   };
 };


### PR DESCRIPTION
This  PR:
- adds the ability to set IAM policies for functions
- adds a `allowUnauthenticated` property to a function as a shortcut for adding the `roles/cloudfunctions.invoker` role for `allUsers`, making the function public (see:  https://cloud.google.com/functions/docs/securing/managing-access-iam#gcloud_4)
- adds test cases for the above

Note that I haven't tested this with an actual deploy because I'm not sure how use my fork of this plugin in a serverless configuration, but I can look into how to get that set up tomorrow.

Relates to:
- #205
- #179 
