### PR TITLE
We are not all in US

### DIFF
--- a/package/lib/prepareDeployment.js
+++ b/package/lib/prepareDeployment.js
@@ -21,7 +21,11 @@ module.exports = {
     const updatedBucket = updateBucketName(bucket, name);
 
     const bucketIndex = deploymentTemplate.resources.findIndex(findDeploymentBucket);
-
+    if (this.serverless.service.provider.region) {
+      updatedBucket.properties.location = this.serverless.service.provider.region
+    } else {
+      unset(updatedBucket.properties)
+    }
     deploymentTemplate.resources[bucketIndex] = updatedBucket;
 
     this.serverless.service.provider.compiledConfigurationTemplate = deploymentTemplate;


### PR DESCRIPTION
Because we are not all in US, i don't understand why the deployment bucket still has to be there by default... Here the deployment bucket uses the provider region for the bucket location.