### PR TITLE
VPC Naming and Egress Setting

### DIFF
--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -63,7 +63,7 @@ module.exports = {
       }
       
 	  if (funcObject.vpcEgress) {
-		  const egress = _.get(funcObject, 'vpcEgress') || _.get(this, 'serverless.service.provider.vpcEgress');
+		  let egress = _.get(funcObject, 'vpcEgress') || _.get(this, 'serverless.service.provider.vpcEgress');
 		  if (egress) {
 			  egress = egress.toUpperCase();
 			  if (egress==='all') egrees = 'ALL_TRAFFIC';

--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -63,7 +63,7 @@ module.exports = {
       }
       
 	  if (funcObject.vpcEgress) {
-		  const egress = (_.get(funcObject, 'vpcEgress') || _.get(this, 'serverless.service.provider.vpcEgress');
+		  const egress = _.get(funcObject, 'vpcEgress') || _.get(this, 'serverless.service.provider.vpcEgress');
 		  if (egress) {
 			  egress = egress.toUpperCase();
 			  if (egress==='all') egrees = 'ALL_TRAFFIC';

--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -160,7 +160,7 @@ const validateVpcConnectorProperty = (funcObject, functionName) => {
 	
 	// vpcConnector argument can be one of two possible formats as described here:
 	// https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#resource:-cloudfunction
-	if (funcObject.vpc.indexOf('/')) {
+	if (funcObject.vpc.indexOf('/')>-1) {
 		const vpcNamePattern = /projects\/[\s\S]*\/locations\/[\s\S]*\/connectors\/[\s\S]*/i;
 		if (!vpcNamePattern.test(funcObject.vpc)) {
 		  const errorMessage = [

--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -66,8 +66,8 @@ module.exports = {
 		  let egress = _.get(funcObject, 'vpcEgress') || _.get(this, 'serverless.service.provider.vpcEgress');
 		  if (egress) {
 			  egress = egress.toUpperCase();
-			  if (egress==='all') egrees = 'ALL_TRAFFIC';
-			  if (egress==='private') egrees = 'PRIVATE_RANGES_ONLY';
+			  if (egress==='all') egress = 'ALL_TRAFFIC';
+			  if (egress==='private') egress = 'PRIVATE_RANGES_ONLY';
 		  }
         _.assign(funcTemplate.properties, {
           vpcConnectorEgressSettings: egress,

--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -24,6 +24,7 @@ module.exports = {
       validateHandlerProperty(funcObject, functionName);
       validateEventsProperty(funcObject, functionName);
       validateVpcConnectorProperty(funcObject, functionName);
+      validateVpcConnectorEgressProperty(funcObject, functionName);
 
       const funcTemplate = getFunctionTemplate(
         funcObject,
@@ -61,14 +62,15 @@ module.exports = {
           vpcConnector: _.get(funcObject, 'vpc') || _.get(this, 'serverless.service.provider.vpc'),
         });
       }
-      
-	  if (funcObject.vpcEgress) {
-		  let egress = _.get(funcObject, 'vpcEgress') || _.get(this, 'serverless.service.provider.vpcEgress');
-		  if (egress) {
-			  egress = egress.toUpperCase();
-			  if (egress==='ALL') egress = 'ALL_TRAFFIC';
-			  if (egress==='PRIVATE') egress = 'PRIVATE_RANGES_ONLY';
-		  }
+
+      if (funcObject.vpcEgress) {
+        let egress =
+          _.get(funcObject, 'vpcEgress') || _.get(this, 'serverless.service.provider.vpcEgress');
+        if (egress) {
+          egress = egress.toUpperCase();
+          if (egress === 'ALL') egress = 'ALL_TRAFFIC';
+          if (egress === 'PRIVATE') egress = 'PRIVATE_RANGES_ONLY';
+        }
         _.assign(funcTemplate.properties, {
           vpcConnectorEgressSettings: egress,
         });
@@ -157,39 +159,42 @@ const validateEventsProperty = (funcObject, functionName) => {
 
 const validateVpcConnectorProperty = (funcObject, functionName) => {
   if (funcObject.vpc && typeof funcObject.vpc === 'string') {
-	
-	// vpcConnector argument can be one of two possible formats as described here:
-	// https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#resource:-cloudfunction
-	if (funcObject.vpc.indexOf('/')>-1) {
-		const vpcNamePattern = /projects\/[\s\S]*\/locations\/[\s\S]*\/connectors\/[\s\S]*/i;
-		if (!vpcNamePattern.test(funcObject.vpc)) {
-		  const errorMessage = [
-			`The function "${functionName}" has invalid vpc connection name`,
-			' VPC Connector name should follow projects/{project_id}/locations/{region}/connectors/{connector_name}',
-			' or just {connector_name} if within the same project.',
-			' Please check the docs for more info at ',
-			' https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#resource:-cloudfunction',
-		  ].join('');
-		  throw new Error(errorMessage);
-		}	
-	}
+    // vpcConnector argument can be one of two possible formats as described here:
+    // https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#resource:-cloudfunction
+    if (funcObject.vpc.indexOf('/') > -1) {
+      const vpcNamePattern = /projects\/[\s\S]*\/locations\/[\s\S]*\/connectors\/[\s\S]*/i;
+      if (!vpcNamePattern.test(funcObject.vpc)) {
+        const errorMessage = [
+          `The function "${functionName}" has invalid vpc connection name`,
+          ' VPC Connector name should follow projects/{project_id}/locations/{region}/connectors/{connector_name}',
+          ' or just {connector_name} if within the same project.',
+          ' Please check the docs for more info at ',
+          ' https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#resource:-cloudfunction',
+        ].join('');
+        throw new Error(errorMessage);
+      }
+    }
   }
 };
 
 const validateVpcConnectorEgressProperty = (funcObject, functionName) => {
   if (funcObject.vpcEgress && typeof funcObject.vpcEgress === 'string') {
-	  const egress = funcObject.vpcEgress.toUpperCase();
-	  if (egress!=='ALL' && egress!=='ALL_TRAFFIC' && egress!=='PRIVATE' && egress!=='PRIVATE_RANGES_ONLY') {
-		const errorMessage = [
-			`The function "${functionName}" has invalid vpc connection name`,
-			' VPC Connector Egress Setting be either ALL_TRAFFIC or PRIVATE_RANGES_ONLY. ',
-			' You may shorten these to ALL or PRIVATE optionally.',
-			' Please check the docs for more info at',
-			' https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#resource:-cloudfunction',
-		  ].join('');
-		  throw new Error(errorMessage);
-
-	  }
+    const egress = funcObject.vpcEgress.toUpperCase();
+    if (
+      egress !== 'ALL' &&
+      egress !== 'ALL_TRAFFIC' &&
+      egress !== 'PRIVATE' &&
+      egress !== 'PRIVATE_RANGES_ONLY'
+    ) {
+      const errorMessage = [
+        `The function "${functionName}" has invalid vpc connection name`,
+        ' VPC Connector Egress Setting be either ALL_TRAFFIC or PRIVATE_RANGES_ONLY. ',
+        ' You may shorten these to ALL or PRIVATE optionally.',
+        ' Please check the docs for more info at',
+        ' https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#resource:-cloudfunction',
+      ].join('');
+      throw new Error(errorMessage);
+    }
   }
 };
 

--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -66,8 +66,8 @@ module.exports = {
 		  let egress = _.get(funcObject, 'vpcEgress') || _.get(this, 'serverless.service.provider.vpcEgress');
 		  if (egress) {
 			  egress = egress.toUpperCase();
-			  if (egress==='all') egress = 'ALL_TRAFFIC';
-			  if (egress==='private') egress = 'PRIVATE_RANGES_ONLY';
+			  if (egress==='ALL') egress = 'ALL_TRAFFIC';
+			  if (egress==='PRIVATE') egress = 'PRIVATE_RANGES_ONLY';
 		  }
         _.assign(funcTemplate.properties, {
           vpcConnectorEgressSettings: egress,

--- a/package/lib/compileFunctions.test.js
+++ b/package/lib/compileFunctions.test.js
@@ -767,4 +767,128 @@ describe('CompileFunctions', () => {
       });
     });
   });
+
+  it('should allow vpc as short name', () => {
+    googlePackage.serverless.service.functions = {
+      func1: {
+        handler: 'func1',
+        memorySize: 128,
+        runtime: 'nodejs10',
+        vpc: 'my-vpc',
+        events: [{ http: 'foo' }],
+      },
+    };
+
+    const compiledResources = [
+      {
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
+        name: 'my-service-dev-func1',
+        properties: {
+          parent: 'projects/myProject/locations/us-central1',
+          runtime: 'nodejs10',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
+          availableMemoryMb: 128,
+          timeout: '60s',
+          sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
+          httpsTrigger: {
+            url: 'foo',
+          },
+          labels: {},
+          vpcConnector: 'my-vpc',
+        },
+      },
+    ];
+
+    return googlePackage.compileFunctions().then(() => {
+      expect(consoleLogStub.called).toEqual(true);
+      expect(
+        googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources
+      ).toEqual(compiledResources);
+    });
+  });
+
+  it('should allow vpc egress all', () => {
+    googlePackage.serverless.service.functions = {
+      func1: {
+        handler: 'func1',
+        memorySize: 128,
+        runtime: 'nodejs10',
+        vpc: 'my-vpc',
+        vpcEgress: 'all',
+        events: [{ http: 'foo' }],
+      },
+    };
+
+    const compiledResources = [
+      {
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
+        name: 'my-service-dev-func1',
+        properties: {
+          parent: 'projects/myProject/locations/us-central1',
+          runtime: 'nodejs10',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
+          availableMemoryMb: 128,
+          timeout: '60s',
+          sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
+          httpsTrigger: {
+            url: 'foo',
+          },
+          labels: {},
+          vpcConnector: 'my-vpc',
+          vpcConnectorEgressSettings: 'ALL_TRAFFIC',
+        },
+      },
+    ];
+
+    return googlePackage.compileFunctions().then(() => {
+      expect(consoleLogStub.called).toEqual(true);
+      expect(
+        googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources
+      ).toEqual(compiledResources);
+    });
+  });
+
+  it('should allow vpc egress private', () => {
+    googlePackage.serverless.service.functions = {
+      func1: {
+        handler: 'func1',
+        memorySize: 128,
+        runtime: 'nodejs10',
+        vpc: 'my-vpc',
+        vpcEgress: 'private',
+        events: [{ http: 'foo' }],
+      },
+    };
+
+    const compiledResources = [
+      {
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
+        name: 'my-service-dev-func1',
+        properties: {
+          parent: 'projects/myProject/locations/us-central1',
+          runtime: 'nodejs10',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
+          availableMemoryMb: 128,
+          timeout: '60s',
+          sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
+          httpsTrigger: {
+            url: 'foo',
+          },
+          labels: {},
+          vpcConnector: 'my-vpc',
+          vpcConnectorEgressSettings: 'PRIVATE_RANGES_ONLY',
+        },
+      },
+    ];
+
+    return googlePackage.compileFunctions().then(() => {
+      expect(consoleLogStub.called).toEqual(true);
+      expect(
+        googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources
+      ).toEqual(compiledResources);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #242 

This PR address to issues with defining VPC connectors for a google cloud function:
 - First, VPC Connectors can be named with a url (which is the current pattern) or with just the name of the connector if it is within the same project and region. This is described here: https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#resource:-cloudfunction
 - Second, this PR adds the ability to specify a VPC Egress setting.  This is done using the `vpcEgress` property in the serverless.yml file. This property can take one of four different values:
   - `ALL_TRAFFIC`
   - `PRIVATE_RANGES_ONLY`
   - `ALL` (A shortcut for `ALL_TRAFFIC`)
   - `PRIVATE` (A shortcut for `PRIVATE_RANGES_ONLY`)

Also added smattering of tests to verify these changes.

Enjoy.