### PR TITLE
feat: Add schema validation

### DIFF
--- a/package/googlePackage.js
+++ b/package/googlePackage.js
@@ -18,6 +18,23 @@ class GooglePackage {
     this.serverless = serverless;
     this.options = options;
     this.provider = this.serverless.getProvider('google');
+    this.serverless.configSchemaHandler.defineFunctionEvent('google', 'http', { type: 'string' });
+    this.serverless.configSchemaHandler.defineFunctionEvent('google', 'event', {
+      type: 'object',
+      properties: {
+        eventType: {
+          type: 'string',
+        },
+        path: {
+          type: 'string',
+        },
+        resource: {
+          type: 'string',
+        },
+      },
+      required: ['eventType', 'resource'],
+      additionalProperties: false,
+    });
 
     Object.assign(
       this,

--- a/package/googlePackage.test.js
+++ b/package/googlePackage.test.js
@@ -35,6 +35,22 @@ describe('GooglePackage', () => {
       expect(googlePackage.provider).toBeInstanceOf(GoogleProvider);
     });
 
+    it('should define the schema of the http triggered function', () => {
+      expect(serverless.configSchemaHandler.defineFunctionEvent).toHaveBeenCalledWith(
+        'google',
+        'http',
+        expect.any(Object)
+      );
+    });
+
+    it('should define the schema of the event triggered function', () => {
+      expect(serverless.configSchemaHandler.defineFunctionEvent).toHaveBeenCalledWith(
+        'google',
+        'event',
+        expect.any(Object)
+      );
+    });
+
     describe('hooks', () => {
       let cleanupServerlessDirStub;
       let validateStub;

--- a/provider/googleProvider.js
+++ b/provider/googleProvider.js
@@ -22,6 +22,111 @@ class GoogleProvider {
     this.serverless = serverless;
     this.provider = this; // only load plugin in a Google service context
     this.serverless.setProvider(constants.providerName, this);
+    this.serverless.configSchemaHandler.defineProvider(constants.providerName, {
+      definitions: {
+        cloudFunctionRegion: {
+          // Source: https://cloud.google.com/functions/docs/locations
+          enum: [
+            // Tier pricing 1
+            'us-central1', // (Iowa)
+            'us-east1', // (South Carolina)
+            'us-east4', // (Northern Virginia)
+            'europe-west1', // (Belgium)
+            'europe-west2', // (London)
+            'asia-east2', // (Hong Kong)
+            'asia-northeast1', // (Tokyo)
+            'asia-northeast2', // (Osaka)
+            // Tier pricing 2
+            'us-west2', // (Los Angeles)
+            'us-west3', // (Salt Lake City)
+            'us-west4', // (Las Vegas)
+            'northamerica-northeast1', // (Montreal)
+            'southamerica-east1', // (Sao Paulo)
+            'europe-west3', // (Frankfurt)
+            'europe-west6', // (Zurich)
+            'australia-southeast1', // (Sydney)
+            'asia-south1', // (Mumbai)
+            'asia-southeast2', // (Jakarta)
+            'asia-northeast3', // (Seoul)
+          ],
+        },
+        cloudFunctionRuntime: {
+          // Source: https://cloud.google.com/functions/docs/concepts/exec#runtimes
+          enum: [
+            'nodejs6', // decommissioned
+            'nodejs8', // deprecated
+            'nodejs10',
+            'nodejs12',
+            'nodejs14',
+            'python37',
+            'python38',
+            'go111',
+            'go113',
+            'java11',
+            'dotnet3',
+            'ruby26',
+            'ruby27',
+          ],
+        },
+        cloudFunctionMemory: {
+          // Source: https://cloud.google.com/functions/docs/concepts/exec#memory
+          enum: [
+            128,
+            256, // default
+            512,
+            1024,
+            2048,
+            4096,
+          ],
+        },
+        cloudFunctionEnvironmentVariables: {
+          type: 'object',
+          patternProperties: {
+            '^.*$': { type: 'string' },
+          },
+          additionalProperties: false,
+        },
+        resourceManagerLabels: {
+          type: 'object',
+          propertyNames: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 63,
+          },
+          patternProperties: {
+            '^[a-z][a-z0-9_.]*$': { type: 'string' },
+          },
+          additionalProperties: false,
+        },
+      },
+
+      provider: {
+        properties: {
+          credentials: { type: 'string' },
+          project: { type: 'string' },
+          region: { $ref: '#/definitions/cloudFunctionRegion' },
+          runtime: { $ref: '#/definitions/cloudFunctionRuntime' }, // Can be overridden by function configuration
+          serviceAccountEmail: { type: 'string' }, // Can be overridden by function configuration
+          memorySize: { $ref: '#/definitions/cloudFunctionMemory' }, // Can be overridden by function configuration
+          timeout: { type: 'string' }, // Can be overridden by function configuration
+          environment: { $ref: '#/definitions/cloudFunctionEnvironmentVariables' }, // Can be overridden by function configuration
+          vpc: { type: 'string' }, // Can be overridden by function configuration
+          labels: { $ref: '#/definitions/resourceManagerLabels' }, // Can be overridden by function configuration
+        },
+      },
+      function: {
+        properties: {
+          handler: { type: 'string' },
+          runtime: { $ref: '#/definitions/cloudFunctionRuntime' }, // Override provider configuration
+          serviceAccountEmail: { type: 'string' }, // Override provider configuration
+          memorySize: { $ref: '#/definitions/cloudFunctionMemory' }, // Override provider configuration
+          timeout: { type: 'string' }, // Override provider configuration
+          environment: { $ref: '#/definitions/cloudFunctionEnvironmentVariables' }, // Override provider configuration
+          vpc: { type: 'string' }, // Override provider configuration
+          labels: { $ref: '#/definitions/resourceManagerLabels' }, // Override provider configuration
+        },
+      },
+    });
 
     const serverlessVersion = this.serverless.version;
     const pluginVersion = pluginPackageJson.version;

--- a/provider/googleProvider.test.js
+++ b/provider/googleProvider.test.js
@@ -67,6 +67,13 @@ describe('GoogleProvider', () => {
       expect(google._options.headers['User-Agent']) // eslint-disable-line no-underscore-dangle
         .toMatch(/Serverless\/.+ Serverless-Google-Provider\/.+ Googleapis\/.+/);
     });
+
+    it('should define the schema of the provider', () => {
+      expect(serverless.configSchemaHandler.defineProvider).toHaveBeenCalledWith(
+        'google',
+        expect.any(Object)
+      );
+    });
   });
 
   describe('#request()', () => {

--- a/test/serverless.js
+++ b/test/serverless.js
@@ -34,6 +34,11 @@ class Serverless {
     this.pluginManager = {
       addPlugin: (plugin) => this.plugins.push(plugin),
     };
+
+    this.configSchemaHandler = {
+      defineProvider: jest.fn(),
+      defineFunctionEvent: jest.fn(),
+    };
   }
 
   setProvider(name, provider) {


### PR DESCRIPTION
Fixes https://github.com/serverless/serverless-google-cloudfunctions/issues/232

## Description

Validate the serverless configuration for `google` provider and the configuration of the two triggers of cloud functions (`http` and `event`) 

## Tests
I didn't find any test in integration with the `serverless` package so I tested it manually.

`yarn sls package` with this configuration doesn't output any warning
```
service: test-schema-validation
frameworkVersion: '2'
plugins:
  - serverless-google-cloudfunctions

provider:
  name: google
  stage: dev
  runtime: nodejs10
  region: us-central1
  project: my-project
  credentials: ~/.gcloud/keyfile.json
  serviceAccountEmail: 'email'
  memorySize: 512
  timeout: 90s
  environment:
    ENV_VAR_KEY: ENV_VAR_VALUE
  vpc: projects/{project_id}/locations/{region}/connectors/{connector_name}
  labels:
    test.lab_el: VALUE

package:
  exclude:
    - node_modules/**
    - .gitignore
    - .git/**

functions:
  http-function:
    handler: http
    environment:
      ENV_VAR_KEY: ENV_VAR_VALUE
    events:
      - http: path
  event-function:
    handler: http
    vpc: projects/{project_id}/locations/{region}/connectors/{connector_name}
    memorySize: 2048
    timeout: 120s
    labels:
      event_label: VALUE
    events:
      - event:
          eventType: eventType
          resource: resource
```
before this PR the result would have been  
```
Serverless: Configuration warning: Unrecognized provider 'google'                                                                                                                                                  
Serverless:                                                                                                                                                                                                        
Serverless: You're relying on provider plugin which doesn't provide a validation schema for its config.                                                                                                            
Serverless: Please report the issue at its bug tracker linking: https://www.serverless.com/framework/docs/providers/aws/guide/plugins#extending-validation-schema                                                  
Serverless: You may turn off this message with "configValidationMode: off" setting    
```