### PR TITLE
fix: CLI option `count` type deprecation warning

### DIFF
--- a/logs/googleLogs.js
+++ b/logs/googleLogs.js
@@ -19,6 +19,7 @@ class GoogleLogs {
           count: {
             usage: 'Amount of requested logs',
             shortcut: 'c',
+            type: 'string',
           },
         },
       },

--- a/logs/googleLogs.test.js
+++ b/logs/googleLogs.test.js
@@ -52,6 +52,10 @@ describe('GoogleLogs', () => {
       expect(googleLogs.commands.logs.options.count).not.toEqual(undefined);
     });
 
+    it('should have the option "count" with type "string"', () => {
+      expect(googleLogs.commands.logs.options.count.type).toEqual('string');
+    });
+
     describe('hooks', () => {
       let validateStub;
       let setDefaultsStub;

--- a/logs/lib/retrieveLogs.js
+++ b/logs/lib/retrieveLogs.js
@@ -13,7 +13,7 @@ module.exports = {
   getLogs() {
     const project = this.serverless.service.provider.project;
     let func = this.options.function;
-    const pageSize = this.options.count || 10;
+    const pageSize = parseInt(this.options.count, 10) || 10;
 
     func = getGoogleCloudFunctionName(this.serverless.service.functions, func);
 

--- a/logs/lib/retrieveLogs.test.js
+++ b/logs/lib/retrieveLogs.test.js
@@ -97,6 +97,22 @@ describe('RetrieveLogs', () => {
       });
     });
 
+    it('should parse the "count" option as an integer', () => {
+      googleLogs.options.function = 'func1';
+      googleLogs.options.count = '100';
+
+      return googleLogs.getLogs().then(() => {
+        expect(
+          requestStub.calledWithExactly('logging', 'entries', 'list', {
+            filter: 'resource.labels.function_name="full-function-name" AND NOT textPayload=""',
+            orderBy: 'timestamp desc',
+            resourceNames: ['projects/my-project'],
+            pageSize: parseInt(googleLogs.options.count, 10),
+          })
+        ).toEqual(true);
+      });
+    });
+
     it('should throw an error if the function could not be found in the service', () => {
       googleLogs.options.function = 'missingFunc';
 


### PR DESCRIPTION
Closes https://github.com/serverless/serverless-google-cloudfunctions/issues/256

Possible options are:
  - string
  - boolean
  - multiple (strings)
 
I selected "string" and added a `parseInt` to handle the option correctly internally. Let me know if I should go a different direction!