### PR TITLE
chore: Do not run CI tests against Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,9 +101,6 @@ jobs:
     - name: 'Unit Tests - Node.js v10'
       node_js: 10
 
-    - name: 'Unit Tests - Node.js v8'
-      node_js: 8
-
     - stage: Tag on Release
       name: 'Tag on Release'
       node_js: 12


### PR DESCRIPTION
Do not run tests against Node 8 as it's no longer supported