### PR TITLE
feat: Add support for http events in invoke local

### DIFF
--- a/invokeLocal/googleInvokeLocal.js
+++ b/invokeLocal/googleInvokeLocal.js
@@ -29,7 +29,7 @@ class GoogleInvokeLocal {
 
   async invokeLocal() {
     const functionObj = this.serverless.service.getFunction(this.options.function);
-    this.validateEventsProperty(functionObj, this.options.function, ['event']); // Only event is currently supported
+    this.validateEventsProperty(functionObj, this.options.function);
 
     const runtime = this.provider.getRuntime(functionObj);
     if (!runtime.startsWith('nodejs')) {

--- a/invokeLocal/googleInvokeLocal.test.js
+++ b/invokeLocal/googleInvokeLocal.test.js
@@ -165,9 +165,7 @@ describe('GoogleInvokeLocal', () => {
 
     it('should validate the function configuration', async () => {
       await googleInvokeLocal.invokeLocal();
-      expect(
-        validateEventsPropertyStub.calledOnceWith(functionObj, functionName, ['event'])
-      ).toEqual(true);
+      expect(validateEventsPropertyStub.calledOnceWith(functionObj, functionName)).toEqual(true);
     });
 
     it('should get the runtime', async () => {

--- a/invokeLocal/lib/httpReqRes.js
+++ b/invokeLocal/lib/httpReqRes.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const express = require('express');
+const http = require('http');
+const net = require('net');
+
+// The getReqRes method create an express request and an express response
+// as they are created in an express server before being passed to the middlewares
+// Google use express 4.17.1 to run http cloud function
+// https://cloud.google.com/functions/docs/writing/http#http_frameworks
+const app = express();
+
+module.exports = {
+  getReqRes() {
+    const req = new http.IncomingMessage(new net.Socket());
+    const expressRequest = Object.assign(req, { app });
+    Object.setPrototypeOf(expressRequest, express.request);
+
+    const res = new http.ServerResponse(req);
+    const expressResponse = Object.assign(res, { app, req: expressRequest });
+    Object.setPrototypeOf(expressResponse, express.response);
+
+    expressRequest.res = expressResponse;
+
+    return {
+      expressRequest,
+      expressResponse,
+    };
+  },
+};

--- a/invokeLocal/lib/nodeJs.test.js
+++ b/invokeLocal/lib/nodeJs.test.js
@@ -7,14 +7,6 @@ const Serverless = require('../../test/serverless');
 
 jest.spyOn(console, 'log');
 describe('invokeLocalNodeJs', () => {
-  const eventName = 'eventName';
-  const contextName = 'contextName';
-  const event = {
-    name: eventName,
-  };
-  const context = {
-    name: contextName,
-  };
   const myVarValue = 'MY_VAR_VALUE';
   let serverless;
   let googleInvokeLocal;
@@ -29,57 +21,160 @@ describe('invokeLocalNodeJs', () => {
     serverless.cli.consoleLog = jest.fn();
     googleInvokeLocal = new GoogleInvokeLocal(serverless, {});
   });
-
-  it('should invoke a sync handler', async () => {
-    const functionConfig = {
-      handler: 'syncHandler',
+  describe('event', () => {
+    const eventName = 'eventName';
+    const contextName = 'contextName';
+    const event = {
+      name: eventName,
     };
-    await googleInvokeLocal.invokeLocalNodeJs(functionConfig, event, context);
-    // eslint-disable-next-line no-console
-    expect(console.log).toHaveBeenCalledWith('SYNC_HANDLER');
-    expect(serverless.cli.consoleLog).toHaveBeenCalledWith(`{\n    "result": "${eventName}"\n}`);
+    const context = {
+      name: contextName,
+    };
+    const baseConfig = {
+      events: [{ event: {} }],
+    };
+    it('should invoke a sync handler', async () => {
+      const functionConfig = {
+        ...baseConfig,
+        handler: 'eventSyncHandler',
+      };
+      await googleInvokeLocal.invokeLocalNodeJs(functionConfig, event, context);
+      // eslint-disable-next-line no-console
+      expect(console.log).toHaveBeenCalledWith('EVENT_SYNC_HANDLER');
+      expect(serverless.cli.consoleLog).toHaveBeenCalledWith(`{\n    "result": "${eventName}"\n}`);
+    });
+
+    it('should handle errors in a sync handler', async () => {
+      const functionConfig = {
+        ...baseConfig,
+        handler: 'eventSyncHandlerWithError',
+      };
+      await googleInvokeLocal.invokeLocalNodeJs(functionConfig, event, context);
+      // eslint-disable-next-line no-console
+      expect(console.log).toHaveBeenCalledWith('EVENT_SYNC_HANDLER');
+      expect(serverless.cli.consoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('"errorMessage": "SYNC_ERROR"')
+      );
+    });
+
+    it('should invoke an async handler', async () => {
+      const functionConfig = {
+        ...baseConfig,
+        handler: 'eventAsyncHandler',
+      };
+      await googleInvokeLocal.invokeLocalNodeJs(functionConfig, event, context);
+      // eslint-disable-next-line no-console
+      expect(console.log).toHaveBeenCalledWith('EVENT_ASYNC_HANDLER');
+      expect(serverless.cli.consoleLog).toHaveBeenCalledWith(
+        `{\n    "result": "${contextName}"\n}`
+      );
+    });
+
+    it('should handle errors in an async handler', async () => {
+      const functionConfig = {
+        ...baseConfig,
+        handler: 'eventAsyncHandlerWithError',
+      };
+      await googleInvokeLocal.invokeLocalNodeJs(functionConfig, event, context);
+      // eslint-disable-next-line no-console
+      expect(console.log).toHaveBeenCalledWith('EVENT_ASYNC_HANDLER');
+      expect(serverless.cli.consoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('"errorMessage": "ASYNC_ERROR"')
+      );
+    });
+
+    it('should give the environment variables to the handler', async () => {
+      const functionConfig = {
+        ...baseConfig,
+        handler: 'eventEnvHandler',
+      };
+      await googleInvokeLocal.invokeLocalNodeJs(functionConfig, event, context);
+      // eslint-disable-next-line no-console
+      expect(console.log).toHaveBeenCalledWith(myVarValue);
+    });
   });
-
-  it('should handle errors in a sync handler', async () => {
-    const functionConfig = {
-      handler: 'syncHandlerWithError',
+  describe('http', () => {
+    const message = 'httpBodyMessage';
+    const req = {
+      body: { message },
     };
-    await googleInvokeLocal.invokeLocalNodeJs(functionConfig, event, context);
-    // eslint-disable-next-line no-console
-    expect(console.log).toHaveBeenCalledWith('SYNC_HANDLER');
-    expect(serverless.cli.consoleLog).toHaveBeenCalledWith(
-      expect.stringContaining('"errorMessage": "SYNC_ERROR"')
-    );
-  });
-
-  it('should invoke an async handler', async () => {
-    const functionConfig = {
-      handler: 'asyncHandler',
+    const context = {};
+    const baseConfig = {
+      events: [{ http: '' }],
     };
-    await googleInvokeLocal.invokeLocalNodeJs(functionConfig, event, context);
-    // eslint-disable-next-line no-console
-    expect(console.log).toHaveBeenCalledWith('ASYNC_HANDLER');
-    expect(serverless.cli.consoleLog).toHaveBeenCalledWith(`{\n    "result": "${contextName}"\n}`);
-  });
+    it('should invoke a sync handler', async () => {
+      const functionConfig = {
+        ...baseConfig,
+        handler: 'httpSyncHandler',
+      };
+      await googleInvokeLocal.invokeLocalNodeJs(functionConfig, req, context);
+      // eslint-disable-next-line no-console
+      expect(console.log).toHaveBeenCalledWith('HTTP_SYNC_HANDLER');
+      expect(serverless.cli.consoleLog).toHaveBeenCalledWith(
+        JSON.stringify(
+          {
+            status: 200,
+            headers: {
+              'x-test': 'headerValue',
+              'content-type': 'application/json; charset=utf-8',
+              'content-length': '37',
+              'etag': 'W/"25-F1uWAIMs2TbWZIN1zJauHXahSdU"',
+            },
+            body: { responseMessage: message },
+          },
+          null,
+          4
+        )
+      );
+    });
 
-  it('should handle errors in an async handler', async () => {
-    const functionConfig = {
-      handler: 'asyncHandlerWithError',
-    };
-    await googleInvokeLocal.invokeLocalNodeJs(functionConfig, event, context);
-    // eslint-disable-next-line no-console
-    expect(console.log).toHaveBeenCalledWith('ASYNC_HANDLER');
-    expect(serverless.cli.consoleLog).toHaveBeenCalledWith(
-      expect.stringContaining('"errorMessage": "ASYNC_ERROR"')
-    );
-  });
+    it('should handle errors in a sync handler', async () => {
+      const functionConfig = {
+        ...baseConfig,
+        handler: 'httpSyncHandlerWithError',
+      };
+      await googleInvokeLocal.invokeLocalNodeJs(functionConfig, req, context);
+      // eslint-disable-next-line no-console
+      expect(console.log).toHaveBeenCalledWith('HTTP_SYNC_HANDLER');
+      expect(serverless.cli.consoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('"errorMessage": "SYNC_ERROR"')
+      );
+    });
 
-  it('should give the environment variables to the handler', async () => {
-    const functionConfig = {
-      handler: 'envHandler',
-    };
-    await googleInvokeLocal.invokeLocalNodeJs(functionConfig, event, context);
-    // eslint-disable-next-line no-console
-    expect(console.log).toHaveBeenCalledWith(myVarValue);
+    it('should invoke an async handler', async () => {
+      const functionConfig = {
+        ...baseConfig,
+        handler: 'httpAsyncHandler',
+      };
+      await googleInvokeLocal.invokeLocalNodeJs(functionConfig, req, context);
+      // eslint-disable-next-line no-console
+      expect(console.log).toHaveBeenCalledWith('HTTP_ASYNC_HANDLER');
+      expect(serverless.cli.consoleLog).toHaveBeenCalledWith(
+        JSON.stringify({ status: 404, headers: {} }, null, 4)
+      );
+    });
+
+    it('should handle errors in an async handler', async () => {
+      const functionConfig = {
+        ...baseConfig,
+        handler: 'httpAsyncHandlerWithError',
+      };
+      await googleInvokeLocal.invokeLocalNodeJs(functionConfig, req, context);
+      // eslint-disable-next-line no-console
+      expect(console.log).toHaveBeenCalledWith('HTTP_ASYNC_HANDLER');
+      expect(serverless.cli.consoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('"errorMessage": "ASYNC_ERROR"')
+      );
+    });
+
+    it('should give the environment variables to the handler', async () => {
+      const functionConfig = {
+        ...baseConfig,
+        handler: 'httpEnvHandler',
+      };
+      await googleInvokeLocal.invokeLocalNodeJs(functionConfig, req, context);
+      // eslint-disable-next-line no-console
+      expect(console.log).toHaveBeenCalledWith(myVarValue);
+    });
   });
 });

--- a/invokeLocal/lib/testMocks/index.js
+++ b/invokeLocal/lib/testMocks/index.js
@@ -3,30 +3,61 @@
  */
 
 'use strict';
+const wait = () => new Promise((resolve) => setTimeout(resolve, 10));
 
 module.exports = {
-  syncHandler: (event, context, callback) => {
+  eventSyncHandler: (event, context, callback) => {
     // eslint-disable-next-line no-console
-    console.log('SYNC_HANDLER');
+    console.log('EVENT_SYNC_HANDLER');
     callback(null, { result: event.name });
   },
-  syncHandlerWithError: (event, context, callback) => {
+  eventSyncHandlerWithError: (event, context, callback) => {
     // eslint-disable-next-line no-console
-    console.log('SYNC_HANDLER');
+    console.log('EVENT_SYNC_HANDLER');
     callback('SYNC_ERROR');
   },
-  asyncHandler: async (event, context) => {
+  eventAsyncHandler: async (event, context) => {
     // eslint-disable-next-line no-console
-    console.log('ASYNC_HANDLER');
+    console.log('EVENT_ASYNC_HANDLER');
+    await wait();
     return { result: context.name };
   },
-  asyncHandlerWithError: async () => {
+  eventAsyncHandlerWithError: async () => {
     // eslint-disable-next-line no-console
-    console.log('ASYNC_HANDLER');
+    console.log('EVENT_ASYNC_HANDLER');
+    await wait();
     throw new Error('ASYNC_ERROR');
   },
-  envHandler: async () => {
+  eventEnvHandler: async () => {
     // eslint-disable-next-line no-console
     console.log(process.env.MY_VAR);
+  },
+  httpSyncHandler: (req, res) => {
+    // eslint-disable-next-line no-console
+    console.log('HTTP_SYNC_HANDLER');
+    res.setHeader('x-test', 'headerValue');
+    res.send({ responseMessage: req.body.message });
+  },
+  httpSyncHandlerWithError: () => {
+    // eslint-disable-next-line no-console
+    console.log('HTTP_SYNC_HANDLER');
+    throw new Error('SYNC_ERROR');
+  },
+  httpAsyncHandler: async (req, res) => {
+    // eslint-disable-next-line no-console
+    console.log('HTTP_ASYNC_HANDLER');
+    await wait();
+    res.status(404).send();
+  },
+  httpAsyncHandlerWithError: async () => {
+    // eslint-disable-next-line no-console
+    console.log('HTTP_ASYNC_HANDLER');
+    await wait();
+    throw new Error('ASYNC_ERROR');
+  },
+  httpEnvHandler: (req, res) => {
+    // eslint-disable-next-line no-console
+    console.log(process.env.MY_VAR);
+    res.send('HTTP_SYNC_BODY');
   },
 };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "async": "^2.6.3",
     "bluebird": "^3.7.2",
     "chalk": "^3.0.0",
+    "express": "4.17.1",
     "fs-extra": "^8.1.0",
     "get-stdin": "^8.0.0",
     "googleapis": "^50.0.0",


### PR DESCRIPTION
## Description

This pull request follows https://github.com/serverless/serverless-google-cloudfunctions/pull/258 and adds the implementation of the command invoke local for HTTP events from the google provider.

## Implementation

[Cloud functions triggered by HTTP use express 4.17.1.](https://cloud.google.com/functions/docs/writing/http#http_frameworks)

1. Default `req` and `res` are recreated as they are provided by express to the handler in the cloud
2. The content of req is overridden by the data provided for the local execution
3. The `end` method of `res` is overridden by a custom method to 
      1. prevent the default behavior of `end` (send back the response to the client) 
      2. get the body of the response to logging it
      3. end the local invocation 

## Tests
 
- [x] Units
- [x] e2e with ES5 JS
- [x] e2e with compiled JS/TS with [webpack](https://github.com/serverless-heaven/serverless-webpack) 
- [x] e2e with compiled JS/TS with [esbuild](https://github.com/floydspace/serverless-esbuild)

## Next steps

- Document the usage of the command: https://github.com/serverless/serverless/pull/9603