### PR TITLE
feat: build environment variables

### DIFF
--- a/package/lib/compileFunctions.js
+++ b/package/lib/compileFunctions.js
@@ -49,6 +49,8 @@ module.exports = {
         _.get(funcObject, 'timeout') || _.get(this, 'serverless.service.provider.timeout') || '60s';
       funcTemplate.properties.environmentVariables =
         this.provider.getConfiguredEnvironment(funcObject);
+      funcTemplate.properties.buildEnvironmentVariables =
+        this.provider.getConfiguredBuildEnvironment(funcObject);
 
       if (!funcTemplate.properties.serviceAccountEmail) {
         delete funcTemplate.properties.serviceAccountEmail;
@@ -75,6 +77,9 @@ module.exports = {
 
       if (!_.size(funcTemplate.properties.environmentVariables)) {
         delete funcTemplate.properties.environmentVariables;
+      }
+      if (!_.size(funcTemplate.properties.buildEnvironmentVariables)) {
+        delete funcTemplate.properties.buildEnvironmentVariables;
       }
 
       funcTemplate.properties.labels = _.assign(

--- a/package/lib/compileFunctions.test.js
+++ b/package/lib/compileFunctions.test.js
@@ -507,6 +507,143 @@ describe('CompileFunctions', () => {
       });
     });
 
+    it('should set the build environment variables based on the function configuration', () => {
+      googlePackage.serverless.service.functions = {
+        func1: {
+          handler: 'func1',
+          buildEnvironment: {
+            TEST_VAR: 'test',
+          },
+          events: [{ http: 'foo' }],
+        },
+      };
+
+      const compiledResources = [
+        {
+          type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
+          name: 'my-service-dev-func1',
+          properties: {
+            parent: 'projects/myProject/locations/us-central1',
+            runtime: 'nodejs10',
+            function: 'my-service-dev-func1',
+            entryPoint: 'func1',
+            availableMemoryMb: 256,
+            buildEnvironmentVariables: {
+              TEST_VAR: 'test',
+            },
+            timeout: '60s',
+            sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
+            httpsTrigger: {
+              url: 'foo',
+            },
+            labels: {},
+          },
+        },
+      ];
+
+      return googlePackage.compileFunctions().then(() => {
+        expect(consoleLogStub.calledOnce).toEqual(true);
+        expect(
+          googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources
+        ).toEqual(compiledResources);
+      });
+    });
+
+    it('should set the build environment variables based on the provider configuration', () => {
+      googlePackage.serverless.service.functions = {
+        func1: {
+          handler: 'func1',
+          events: [{ http: 'foo' }],
+        },
+      };
+      googlePackage.serverless.service.provider.buildEnvironment = {
+        TEST_VAR: 'test',
+      };
+
+      const compiledResources = [
+        {
+          type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
+          name: 'my-service-dev-func1',
+          properties: {
+            parent: 'projects/myProject/locations/us-central1',
+            runtime: 'nodejs10',
+            function: 'my-service-dev-func1',
+            entryPoint: 'func1',
+            availableMemoryMb: 256,
+            buildEnvironmentVariables: {
+              TEST_VAR: 'test',
+            },
+            timeout: '60s',
+            sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
+            httpsTrigger: {
+              url: 'foo',
+            },
+            labels: {},
+          },
+        },
+      ];
+
+      return googlePackage.compileFunctions().then(() => {
+        expect(consoleLogStub.calledOnce).toEqual(true);
+        expect(
+          googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources
+        ).toEqual(compiledResources);
+      });
+    });
+
+    it('should merge the build environment variables on the provider configuration and function definition', () => {
+      googlePackage.serverless.service.functions = {
+        func1: {
+          handler: 'func1',
+          buildEnvironment: {
+            TEST_VAR: 'test_var',
+            TEST_VALUE: 'foobar',
+          },
+          events: [{ http: 'foo' }],
+        },
+      };
+      googlePackage.serverless.service.provider.buildEnvironment = {
+        TEST_VAR: 'test',
+        TEST_FOO: 'foo',
+      };
+
+      const compiledResources = [
+        {
+          type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
+          name: 'my-service-dev-func1',
+          properties: {
+            parent: 'projects/myProject/locations/us-central1',
+            runtime: 'nodejs10',
+            function: 'my-service-dev-func1',
+            entryPoint: 'func1',
+            availableMemoryMb: 256,
+            buildEnvironmentVariables: {
+              TEST_VAR: 'test_var',
+              TEST_VALUE: 'foobar',
+              TEST_FOO: 'foo',
+            },
+            timeout: '60s',
+            sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
+            httpsTrigger: {
+              url: 'foo',
+            },
+            labels: {},
+          },
+        },
+      ];
+
+      return googlePackage.compileFunctions().then(() => {
+        expect(consoleLogStub.calledOnce).toEqual(true);
+        expect(
+          googlePackage.serverless.service.provider.compiledConfigurationTemplate.resources
+        ).toEqual(compiledResources);
+        expect(googlePackage.serverless.service.provider.buildEnvironment).toEqual({
+          TEST_VAR: 'test',
+          TEST_FOO: 'foo',
+        });
+      });
+    });
+
     it('should compile "http" events properly', () => {
       googlePackage.serverless.service.functions = {
         func1: {

--- a/provider/googleProvider.js
+++ b/provider/googleProvider.js
@@ -89,6 +89,13 @@ class GoogleProvider {
         cloudFunctionVpcEgress: {
           enum: ['ALL', 'ALL_TRAFFIC', 'PRIVATE', 'PRIVATE_RANGES_ONLY'],
         },
+        cloudFunctionBuildEnvironmentVariables: {
+          type: 'object',
+          patternProperties: {
+            '^.*$': { type: 'string' },
+          },
+          additionalProperties: false,
+        },
         resourceManagerLabels: {
           type: 'object',
           propertyNames: {
@@ -113,6 +120,7 @@ class GoogleProvider {
           memorySize: { $ref: '#/definitions/cloudFunctionMemory' }, // Can be overridden by function configuration
           timeout: { type: 'string' }, // Can be overridden by function configuration
           environment: { $ref: '#/definitions/cloudFunctionEnvironmentVariables' }, // Can be overridden by function configuration
+          buildEnvironment: { $ref: '#/definitions/cloudFunctionBuildEnvironmentVariables' }, // Can be overridden by function configuration
           vpc: { type: 'string' }, // Can be overridden by function configuration
           vpcEgress: { $ref: '#/definitions/cloudFunctionVpcEgress' }, // Can be overridden by function configuration
           labels: { $ref: '#/definitions/resourceManagerLabels' }, // Can be overridden by function configuration
@@ -126,6 +134,7 @@ class GoogleProvider {
           memorySize: { $ref: '#/definitions/cloudFunctionMemory' }, // Override provider configuration
           timeout: { type: 'string' }, // Override provider configuration
           environment: { $ref: '#/definitions/cloudFunctionEnvironmentVariables' }, // Override provider configuration
+          buildEnvironment: { $ref: '#/definitions/cloudFunctionBuildEnvironmentVariables' }, // Override provider configuration
           vpc: { type: 'string' }, // Override provider configuration
           vpcEgress: { $ref: '#/definitions/cloudFunctionVpcEgress' }, // Can be overridden by function configuration
           labels: { $ref: '#/definitions/resourceManagerLabels' }, // Override provider configuration
@@ -258,6 +267,14 @@ class GoogleProvider {
       {},
       _.get(this, 'serverless.service.provider.environment'),
       funcObject.environment
+    );
+  }
+
+  getConfiguredBuildEnvironment(funcObject) {
+    return _.merge(
+      {},
+      _.get(this, 'serverless.service.provider.buildEnvironment'),
+      funcObject.buildEnvironment
     );
   }
 }

--- a/provider/googleProvider.test.js
+++ b/provider/googleProvider.test.js
@@ -230,4 +230,41 @@ describe('GoogleProvider', () => {
       );
     });
   });
+
+  describe('#getConfiguredBuildEnvironment()', () => {
+    const functionBuildEnvironment = {
+      MY_VAR: 'myVarFunctionValue',
+      FUNCTION_VAR: 'functionVarFunctionValue',
+    };
+    const providerBuildEnvironment = {
+      MY_VAR: 'myVarProviderValue',
+      PROVIDER_VAR: 'providerVarProviderValue',
+    };
+
+    it('should return the build environment of the function if defined', () => {
+      expect(
+        googleProvider.getConfiguredBuildEnvironment({ buildEnvironment: functionBuildEnvironment })
+      ).toEqual(functionBuildEnvironment);
+    });
+
+    it('should return the build environment of the provider if defined', () => {
+      serverless.service.provider.buildEnvironment = providerBuildEnvironment;
+      expect(googleProvider.getConfiguredBuildEnvironment({})).toEqual(providerBuildEnvironment);
+    });
+
+    it('should return an empty object if neither the build environment of the function nor the one of the provider are defined', () => {
+      expect(googleProvider.getConfiguredBuildEnvironment({})).toEqual({});
+    });
+
+    it('should return the merged build environment of the provider and the function. The function override the provider.', () => {
+      serverless.service.provider.buildEnvironment = providerBuildEnvironment;
+      expect(
+        googleProvider.getConfiguredBuildEnvironment({ buildEnvironment: functionBuildEnvironment })
+      ).toEqual({
+        MY_VAR: 'myVarFunctionValue',
+        FUNCTION_VAR: 'functionVarFunctionValue',
+        PROVIDER_VAR: 'providerVarProviderValue',
+      });
+    });
+  });
 });


### PR DESCRIPTION
Google allows to update Build Environment Variables on deploy, so let's make use of such opportunity: https://cloud.google.com/functions/docs/env-var#updating_build_environment_variables.

`buildEnvironmentVariables` property is from REST API documentation https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions

---

Now we have a better solution for private Go dependencies than having a `vendor`. With build env vars, you can set `GOPROXY` and buildpack will fetch needed private dependencies through it. Yay.