### PR TITLE
Added support for python39 runtime

### DIFF
--- a/provider/googleProvider.js
+++ b/provider/googleProvider.js
@@ -63,6 +63,7 @@ class GoogleProvider {
             'nodejs14',
             'python37',
             'python38',
+            'python39',
             'go111',
             'go113',
             'java11',


### PR DESCRIPTION
Python 3.9 is generally available and is the recommended Python runtime: https://cloud.google.com/functions/docs/concepts/python-runtime