### PR TITLE
Support new variables resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "sinon": "^8.1.1",
     "standard-version": "^9.3.1"
   },
+  "peerDependencies": {
+    "serverless": "2 || 3"
+  },
   "scripts": {
     "commitlint": "commitlint -f HEAD@{15}",
     "commitlint:pull-request": "commitlint -f HEAD~1",


### PR DESCRIPTION
Additionally documented compatibility with Serverless Framework versions. I decided no to mark v1 as compatible, as since of release of v2, this plugin had two major releases, and dropped support for Node.js versions supported by v1