### PR TITLE
feat: Add support for Node.js 16 and Go 1.16 Runtimes

### DIFF
--- a/provider/googleProvider.js
+++ b/provider/googleProvider.js
@@ -61,6 +61,7 @@ class GoogleProvider {
             'nodejs10',
             'nodejs12',
             'nodejs14',
+            'nodejs16', // recommended
             'python37',
             'python38',
             'python39',

--- a/provider/googleProvider.js
+++ b/provider/googleProvider.js
@@ -67,6 +67,7 @@ class GoogleProvider {
             'python39',
             'go111',
             'go113',
+            'go116', // recommended
             'java11',
             'dotnet3',
             'ruby26',


### PR DESCRIPTION
The Node.js 16 Runtime is available and recommended by Google.
https://cloud.google.com/functions/docs/concepts/nodejs-runtime

The Go 1.16 is available and recommended by Google.
https://cloud.google.com/functions/docs/concepts/go-runtime