### PR TITLE
allow dashes in label keys

### DIFF
--- a/provider/googleProvider.js
+++ b/provider/googleProvider.js
@@ -126,7 +126,7 @@ class GoogleProvider {
             maxLength: 63,
           },
           patternProperties: {
-            '^[a-z][a-z0-9_.]*$': { type: 'string' },
+            '^[a-z][a-z0-9_.-]*$': { type: 'string' },
           },
           additionalProperties: false,
         },


### PR DESCRIPTION
sls deploy was throwing a configuration error when dashes are used in keys.

```
$ serverless deploy
Running "serverless" from node_modules

Warning: Invalid configuration encountered
  at 'provider.labels': unrecognized property 'created-by'

Learn more about configuration validation here: http://slss.io/configuration-validation
```

I think dashes can be included according to the google documentation.
https://cloud.google.com/deployment-manager/docs/creating-managing-labels