### PR TITLE
fix: add missing us-west1 region to schema

### DIFF
--- a/provider/googleProvider.js
+++ b/provider/googleProvider.js
@@ -31,6 +31,7 @@ class GoogleProvider {
             'us-central1', // (Iowa)
             'us-east1', // (South Carolina)
             'us-east4', // (Northern Virginia)
+            'us-west1', // (Oregon)
             'europe-west1', // (Belgium)
             'europe-west2', // (London)
             'asia-east1', // (Taiwan)


### PR DESCRIPTION
`us-west-1` region is currently not supported by this serverless plugin as you can see here: https://github.com/serverless/serverless-google-cloudfunctions/blob/b1cdaf25c1cb782b906ea4bfbf0adbd4b4efa4fd/provider/googleProvider.js#L30

But in the Google documentation you can see that `us-west1` region is available under tier 1 pricing: https://cloud.google.com/functions/docs/locations#tier_1_pricing 

This PR is about adding support for this available region.