### PR TITLE
feat: configure custom IAM roles with set permissions

### DIFF
--- a/package/googlePackage.js
+++ b/package/googlePackage.js
@@ -10,6 +10,7 @@ const prepareDeployment = require('./lib/prepareDeployment');
 const saveCreateTemplateFile = require('./lib/writeFilesToDisk');
 const mergeServiceResources = require('./lib/mergeServiceResources');
 const generateArtifactDirectoryName = require('./lib/generateArtifactDirectoryName');
+const createIamRoles = require('./lib/createIamRoles');
 const compileFunctions = require('./lib/compileFunctions');
 const saveUpdateTemplateFile = require('./lib/writeFilesToDisk');
 
@@ -54,6 +55,7 @@ class GooglePackage {
       prepareDeployment,
       saveCreateTemplateFile,
       generateArtifactDirectoryName,
+      createIamRoles,
       compileFunctions,
       mergeServiceResources,
       saveUpdateTemplateFile
@@ -72,7 +74,9 @@ class GooglePackage {
           .then(this.saveCreateTemplateFile),
 
       'before:package:compileFunctions': () =>
-        BbPromise.bind(this).then(this.generateArtifactDirectoryName),
+        BbPromise.bind(this)
+          .then(this.generateArtifactDirectoryName)
+          .then(this.createIamRoles),
 
       'package:compileFunctions': () => BbPromise.bind(this).then(this.compileFunctions),
 

--- a/package/lib/createIamRoles.js
+++ b/package/lib/createIamRoles.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const _ = require('lodash');
+
+module.exports = {
+  createIamRoles() {
+    const provider = this.serverless.service.provider;
+    const iamConfig = provider.iam;
+    if (!iamConfig || !iamConfig.permissions) return;
+
+    if (provider.serviceAccountEmail) {
+      throw new Error('Cannot set both iam permissions and serviceAccountEmail on provider')
+    }
+
+    const projectId = provider.project;
+    const serviceName = `${this.serverless.service.service}-${this.options.stage}`;
+    const serviceAccountName = `sls-${serviceName}`;
+    const serviceAccountEmail = `${serviceAccountName}@${projectId}.iam.gserviceaccount.com`;
+
+    provider.serviceAccountEmail = serviceAccountEmail;
+
+    const deploymentResources =
+      this.serverless.service.provider.compiledConfigurationTemplate.resources;
+
+    // Create Cloud Function identity service account to assign custom IAM roles to
+    deploymentResources.push({
+      type: 'iam.v1.serviceAccount',
+      name: serviceAccountName,
+      properties: {
+        accountId: serviceAccountName,
+        displayName: serviceAccountName,
+        description: `Generated service account for Serverless project ${serviceName}`,
+      },
+    });
+
+    // Collect all permissions that don't apply to a specific resource
+    const [permissions, resourceSpecificRoles] = _.partition(
+      iamConfig.permissions,
+      (item) => typeof item === 'string'
+    );
+
+    // Create and assign custom role for permissions without a resource
+    if (permissions.length > 0) {
+      const iamObject = { permissions, projectId };
+      const role = getCustomRoleTemplate(projectId, serviceName, iamObject);
+      deploymentResources.push(role);
+      deploymentResources.push(
+        getIamMemberTemplate(projectId, serviceAccountEmail, role, iamObject)
+      );
+    }
+
+    // Create and assign custom role(s) for each specific resource resource
+    resourceSpecificRoles.forEach((iamObject) => {
+      const role = getCustomRoleTemplate(projectId, serviceName, iamObject);
+      deploymentResources.push(role);
+      deploymentResources.push(
+        getIamMemberTemplate(projectId, serviceAccountEmail, role, iamObject)
+      );
+    });
+  },
+};
+
+const getCustomRoleTemplate = (project, serviceName, config) => {
+  const namePrefix = serviceName.slice(0, 48).replaceAll('-', '_');
+  const nameSuffix = getResourceRoleSuffix(config)
+    .replace(/[^a-zA-Z_]/g, '')
+    .slice(0, 64 - namePrefix.length);
+  const name = `${namePrefix}_${nameSuffix}`;
+
+  return {
+    type: 'gcp-types/iam-v1:projects.roles',
+    name,
+    properties: {
+      parent: `projects/${project}`,
+      roleId: name,
+      role: {
+        title: name,
+        description: 'Generated IAM role for Serverless project ${serviceName}',
+        stage: 'GA',
+        includedPermissions: config.permissions,
+      },
+    },
+  };
+};
+
+const getIamMemberTemplate = (project, serviceAccountEmail, role, config) => {
+  const { type, resource } = getIamMembershipResourceType(config);
+
+  return {
+    type,
+    name: `${role.name}_members`,
+    properties: {
+      ...resource,
+      role: `projects/${project}/roles/${role.properties.roleId}`,
+      member: `serviceAccount:${serviceAccountEmail}`,
+    },
+  };
+};
+
+const getResourceRoleSuffix = (config) => {
+  if (config.bucket) return `gcs_${config.bucket}`;
+  if (config.organizationId) return `org_${config.organizationId}`;
+  if (config.folderId) return `fol_${config.folderId}`;
+  if (config.projectId) return `pro_${config.projectId}`;
+  if (config.cloudFunction) return `gcf_${config.cloudFunction}`;
+  return '';
+};
+
+const getIamMembershipResourceType = (config) => {
+  if (config.bucket) {
+    return {
+      type: 'gcp-types/storage-v1:virtual.buckets.iamMemberBinding',
+      resource: {
+        bucket: config.bucket,
+      },
+    };
+  }
+  if (config.organizationId) {
+    return {
+      type: 'gcp-types/cloudresourcemanager-v1:virtual.organizations.iamMemberBinding',
+      resource: {
+        resource: config.organizationId,
+      },
+    };
+  }
+  if (config.folderId) {
+    return {
+      type: 'gcp-types/cloudresourcemanager-v2:virtual.folders.iamMemberBinding',
+      resource: {
+        resource: config.folderId,
+      },
+    };
+  }
+  if (config.projectId) {
+    return {
+      type: 'gcp-types/cloudresourcemanager-v1:virtual.projects.iamMemberBinding',
+      resource: {
+        resource: config.projectId,
+      },
+    };
+  }
+  if (config.cloudFunction) {
+    return {
+      type: 'gcp-types/cloudfunctions-v1:virtual.projects.locations.functions.iamMemberBinding',
+      resource: {
+        resource: config.cloudFunction,
+      },
+    };
+  }
+
+  throw new Error('IAM resource type not supported');
+};

--- a/package/lib/createIamRoles.js
+++ b/package/lib/createIamRoles.js
@@ -49,7 +49,7 @@ module.exports = {
       );
     }
 
-    // Create and assign custom role(s) for each specific resource resource
+    // Create and assign custom role(s) for each specific resource
     resourceSpecificRoles.forEach((iamObject) => {
       const role = getCustomRoleTemplate(projectId, serviceName, iamObject);
       deploymentResources.push(role);
@@ -60,12 +60,13 @@ module.exports = {
   },
 };
 
+const ROLE_NAME_MAX_LENGTH = 64;
 const getCustomRoleTemplate = (project, serviceName, config) => {
   const namePrefix = serviceName.slice(0, 48).replaceAll('-', '_');
   const nameSuffix = getResourceRoleSuffix(config)
     .replace(/[^a-zA-Z_]/g, '')
-    .slice(0, 64 - namePrefix.length);
-  const name = `${namePrefix}_${nameSuffix}`;
+    .slice(0, ROLE_NAME_MAX_LENGTH - namePrefix.length);
+  const name = `${namePrefix}${nameSuffix}`;
 
   return {
     type: 'gcp-types/iam-v1:projects.roles',

--- a/package/lib/createIamRoles.js
+++ b/package/lib/createIamRoles.js
@@ -76,7 +76,7 @@ const getCustomRoleTemplate = (project, serviceName, config) => {
       roleId: name,
       role: {
         title: name,
-        description: 'Generated IAM role for Serverless project ${serviceName}',
+        description: `Generated IAM role for Serverless project ${serviceName}`,
         stage: 'GA',
         includedPermissions: config.permissions,
       },

--- a/provider/googleProvider.js
+++ b/provider/googleProvider.js
@@ -130,8 +130,50 @@ class GoogleProvider {
           },
           additionalProperties: false,
         },
+        iamCustomRoles: {
+          type: 'object',
+          properties: {
+            permissions: {
+              type: 'array',
+              items: {
+                anyOf: [
+                  {
+                    $ref: '#/definitions/iamPermissionsOnResource',
+                  },
+                  {
+                    type: 'string',
+                  },
+                ],
+              },
+            },
+          },
+          additionalProperties: false,
+        },
+        iamPermissionsOnResource: {
+          type: 'object',
+          properties: {
+            bucket: { type: 'string' },
+            organizationId: { type: 'string' },
+            folderId: { type: 'string' },
+            projectId: { type: 'string' },
+            cloudFunction: { type: 'string' },
+            permissions: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+          },
+          additionalProperties: false,
+          oneOf: [
+            { required: ['bucket', 'permissions'] },
+            { required: ['organizationId', 'permissions'] },
+            { required: ['folderId', 'permissions'] },
+            { required: ['projectId', 'permissions'] },
+            { required: ['cloudFunction', 'permissions'] },
+          ]
+        },
       },
-
       provider: {
         properties: {
           credentials: { type: 'string' },
@@ -146,6 +188,7 @@ class GoogleProvider {
           vpc: { type: 'string' }, // Can be overridden by function configuration
           vpcEgress: { $ref: '#/definitions/cloudFunctionVpcEgress' }, // Can be overridden by function configuration
           labels: { $ref: '#/definitions/resourceManagerLabels' }, // Can be overridden by function configuration
+          iam: { $ref: '#/definitions/iamCustomRoles' },
         },
       },
       function: {


### PR DESCRIPTION
secures capabilities of cloud functions by creating custom iam roles for their function identity. takes a different approach from #223 by using Google Deployment Manager to create a service account and custom IAM role(s), and assigning those roles to service account. The deployment manager templates are based on these iam examples: https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/master/dm/templates/iam_custom_role/README.md and https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/master/dm/templates/iam_member/README.md

## Usage

```yaml
# serverless.yaml
provider:
  name: google
  iam:
    permissions:
    - storage.objects.create
    - storage.objects.delete

functions:
  first:
    handler: http
    events:
      - http: true
```
This will create a service account and an IAM role that includes the 2 permissions, set the service account as a member of the role, and assign the service account to the cloud function.

```yaml
# serverless.yaml
provider:
  name: google
  iam:
    permissions:
    - bucket: my-storage-bucket
      permissions:
      - storage.objects.create
      - storage.objects.delete
    - folderId: my-folder-id
      permissions:
      - iam.roles.get
      - iam.roles.list

functions:
  first:
    handler: http
    events:
      - http: true
```
This will do same as above, but create 2 IAM roles and bind them with those specific resources. That is, the `storage` permissions will only apply to `my-storage-bucket` and no other bucket, etc.

### Existing behavior

- Assigning `serviceAccountEmail` to a specific function will override the service account generated with IAM roles & that manual function identity will determine function capabilities
- If `iam` is excluded from the provider definition and no `serviceAccountEmail` is specified, then functions will use the GCP project's default service account, which is the default behavior for deploying a 1st gen cloud function

### TODO

I will add tests if this approach and the configuration setup looks OK
