### PR TITLE
Feat: Add AWS SSM like variable functionality for GCP Secrets Manager

### DIFF
--- a/provider/googleProvider.js
+++ b/provider/googleProvider.js
@@ -198,39 +198,50 @@ class GoogleProvider {
           return { value: await this.gsValue({ bucket, object }) };
         },
       },
-      "gcp-sm": {
+      'gcp-sm': {
         async resolve({ params }) {
           const [value, defaultValue] = params;
-
-          const secretName = `projects/${this.serverless.configurationInput.provider.project}/secrets/${value}/versions/latest`;
+          const secretName = `projects/${serverless.configurationInput.provider.project}/secrets/${value}/versions/latest`;
           try {
+            let credentials = serverless.service.provider.credentials;
+            let auth;
+            if (credentials) {
+              const credParts = serverless.service.provider.credentials.split(path.sep);
+              if (credParts[0] === '~') {
+                credParts[0] = os.homedir();
+                credentials = credParts.reduce((memo, part) => path.join(memo, part), '');
+              }
 
-            const auth = this.getAuthClient();
-
-            const secretManager = google.secretmanager("v1");
-
-            const secretVersion =
-              await secretManager.projects.secrets.versions.access({
-                auth,
-                name: secretName,
+              auth = new google.auth.GoogleAuth({
+                keyFile: credentials.toString(),
+                scopes: 'https://www.googleapis.com/auth/cloud-platform',
+                projectId: serverless.configurationInput.provider.project,
               });
+            }
+
+            auth = new google.auth.GoogleAuth({
+              scopes: 'https://www.googleapis.com/auth/cloud-platform',
+              projectId: serverless.configurationInput.provider.project,
+            });
+
+            const secretManager = google.secretmanager('v1');
+
+            const secretVersion = await secretManager.projects.secrets.versions.access({
+              auth,
+              name: secretName,
+            });
 
             return {
-              value: Buffer.from(
-                secretVersion.data.payload.data,
-                "base64"
-              ).toString("utf-8"),
+              value: Buffer.from(secretVersion.data.payload.data, 'base64').toString('utf-8'),
             };
           } catch (error) {
             if (!defaultValue) {
-              throw new Error(
-                "Variable not found on GCP Secrets Manager: " + value
-              );
+              throw new Error('Variable not found on GCP Secrets Manager: ' + value);
             }
             return { value: defaultValue };
           }
         },
-      }
+      },
     };
 
     // TODO: Remove with next major


### PR DESCRIPTION
# Add AWS SSM like variable functionality for GCP Secrets Manager
The Idea here is to make an alternative like [AWS SSM variables](https://www.serverless.com/framework/docs/providers/aws/guide/variables#reference-variables-using-aws-secrets-manager) from AWS provider on GCP provider.
# How to use it 
Add a variable to your GCP Secrets Manager and call `gcp-sm` passing key value and a default value (optional).
`Example of serverless.yml`:
```yml
service: serverless-gcp-js

provider:
  name: google
  runtime: nodejs18
  region: ${file(./config/config.json):region}
  project: ${file(./config/config.json):project}
  credentials: ${file(./config/config.json):creds-file-path}
  environment:
    VAR1: ${gcp-sm(VAR1)} # Simplest way. Throw error if not found
    VAR2: ${gcp-sm(VAR2,"Default Var")} # Uses "Default Var" as value if not found
    VAR3: ${gcp-sm(VAR3-${opt:stage},"Default Var")} # Search for VAR3- + your stage passed on --stage (error if not passed). If value not found , uses "Default Var" as value
    VAR4: ${gcp-sm(VAR4-${opt:stage,"dev"},"Default Var")} # Search for VAR4- + your stage passed on --stage. If stage not found, uses VAR4-dev as default
    # If value above not found , uses "Default Var" as value

frameworkVersion: "3"

plugins:
  - serverless-google-cloudfunctions

package:
  exclude:
    - node_modules/**
    - .gitignore
    - .git/**

functions:
  first:
    handler: http
    events:
      - http: path
  second:
    handler: http
    environment:
      VAR1: ${gcp-sm(VAR1)} # Simplest way. Throw error if not found
      VAR2: ${gcp-sm(VAR2,"Default Var")} # Uses "Default Var" as value if not found
      VAR3: ${gcp-sm(VAR3-${opt:stage},"Default Var")} # Search for VAR3- + your stage passed on --stage (error if not passed). If value not found , uses "Default Var" as value
      VAR4: ${gcp-sm(VAR4-${opt:stage,"dev"},"Default Var")} # Search for VAR4- + your stage passed on --stage. If stage not found, uses VAR4-dev as default
      # If value above not found , uses "Default Var" as value
    events:
      - http: path

```